### PR TITLE
build(docker): remove USER directive for 65534 (nobody)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ RUN set -ex \
 COPY coredhcp /coredhcp
 
 
-# nobody 65534:65534
-USER 65534:65534
-
 CMD [ "/coredhcp" ]
 
 ENTRYPOINT [ "/sbin/tini", "--" ]


### PR DESCRIPTION
Binding to port 67, a privileged port, requires us to be root. There is no way to specify which port to bind to in the CoreDHCP command line (e.g. via a flag) and it must be done in the config. Thus, it is likely safe to assume the default port 67 will be used in CoreDHCP configurations.