### PR TITLE
fix(coresmd): trim quotes on cert path to actually ignore if empty

### DIFF
--- a/coresmd/main.go
+++ b/coresmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/OpenCHAMI/coresmd/internal/debug"
@@ -69,7 +70,8 @@ func setup4(args ...string) (handler.Handler4, error) {
 	}
 
 	// If nonempty, test that CA cert path exists (third argument)
-	caCertPath := args[2]
+	caCertPath := strings.Trim(args[2], `"'`)
+	log.Infof("cacertPath: %s", caCertPath)
 	if caCertPath != "" {
 		if err := smdClient.UseCACert(caCertPath); err != nil {
 			return nil, fmt.Errorf("failed to set CA certificate: %w", err)


### PR DESCRIPTION
Passing '' or "" as an empty argument would see the cert path be literally quotes (e.g. "" or ''). This PR ensures those characters are trimmed from the output (shallowly) so the string appears as empty when checking if the cert path is set. The certificate path should be optional and this PR ensures that that is enforced.