### PR TITLE
Add tftp to coresmd

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ before:
 builds:
   - id: coredhcp
     main: ./coredhcp/
-    goos:
+    goos:  # CoreDHCP only supports linux
       - linux
     goarch:
       - amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,14 @@ RUN set -ex \
     && rm -rf /var/cache/apk/*  \
     && rm -rf /tmp/*
 
+# Download the latest ipxe binaries from https://github.com/OpenCHAMI/ipxe-binaries/releases and unpack them in the /tftpboot directory.
+RUN set -ex \
+    && mkdir -p /tftpboot \
+    && latest_release_url=$(curl -s https://api.github.com/repos/OpenCHAMI/ipxe-binaries/releases/latest | jq -r '.assets[] | select(.name == "ipxe.tar.gz") | .browser_download_url') \
+    && curl -L $latest_release_url -o /tmp/ipxe.tar.gz \
+    && tar -xzvf /tmp/ipxe.tar.gz -C /tftpboot \
+    && rm /tmp/ipxe.tar.gz
+
 COPY coredhcp /coredhcp
 
 

--- a/coresmd/main.go
+++ b/coresmd/main.go
@@ -98,6 +98,10 @@ func setup4(args ...string) (handler.Handler4, error) {
 
 	cache.RefreshLoop()
 
+	// Start tftpserver
+	log.Info("starting TFTP server on port 69 with directory /tftpboot")
+	go startTFTPServer("/tftpboot")
+
 	log.Infof("coresmd plugin initialized with base URL %s and validity duration %s", smdClient.BaseURL, cache.Duration.String())
 
 	return Handler4, nil

--- a/coresmd/tftp.go
+++ b/coresmd/tftp.go
@@ -1,0 +1,31 @@
+package coresmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pin/tftp"
+)
+
+func startTFTPServer(directory string) {
+	s := tftp.NewServer(readHandler(directory), nil)
+	err := s.ListenAndServe(":69") // default TFTP port
+	if err != nil {
+		log.Fatalf("failed to start TFTP server: %v", err)
+	}
+}
+
+func readHandler(directory string) func(string, io.ReaderFrom) error {
+	return func(filename string, rf io.ReaderFrom) error {
+		filePath := filepath.Join(directory, filename)
+		file, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = rf.ReadFrom(file)
+		return err
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
+	github.com/pin/tftp v2.1.0+incompatible
 	github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pin/tftp v2.1.0+incompatible h1:Yng4J7jv6lOc6IF4XoB5mnd3P7ZrF60XQq+my3FAMus=
+github.com/pin/tftp v2.1.0+incompatible/go.mod h1:xVpZOMCXTy+A5QMjEVN0Glwa1sUvaJhFXbr/aAxuxGY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Adds tftp functionality to coresmd. Only serves out of `/tftpboot` at the moment. 
