### PR TITLE
Correct iPXE architecture-bootloader mapping, set root-path for iPXE bootloader

### DIFF
--- a/coresmd/main.go
+++ b/coresmd/main.go
@@ -134,6 +134,9 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 		resp.Options.Update(dhcpv4.OptHostName(fmt.Sprintf("nid%03d", ifaceInfo.CompNID)))
 	}
 
+	// Set root path to this server's IP
+	resp.Options.Update(dhcpv4.OptRootPath(resp.ServerIPAddr.String()))
+
 	// STEP 2: Send boot config
 	if cinfo := req.Options.Get(dhcpv4.OptionUserClassInformation); string(cinfo) != "iPXE" {
 		// BOOT STAGE 1: Send iPXE bootloader over TFTP

--- a/internal/ipxe/ipxe.go
+++ b/internal/ipxe/ipxe.go
@@ -15,13 +15,25 @@ func ServeIPXEBootloader(l *logrus.Entry, req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHC
 		l.Debugf("client architecture of %s is %v (%q)", req.ClientHWAddr, carchBytes, string(carchBytes))
 		carch = iana.Arch(binary.BigEndian.Uint16(carchBytes))
 		switch carch {
-		case iana.EFI_IA32:
+		case iana.INTEL_X86PC:
 			// iPXE legacy 32-bit x86 bootloader
 			resp.Options.Update(dhcpv4.OptBootFileName("undionly.kpxe"))
 			return resp, true
+		case iana.EFI_IA32:
+			// iPXE EFI 32-bit bootloader
+			resp.Options.Update(dhcpv4.OptBootFileName("ipxe-i386.efi"))
+			return resp, true
 		case iana.EFI_X86_64:
 			// iPXE 64-bit x86 bootloader
-			resp.Options.Update(dhcpv4.OptBootFileName("ipxe.efi"))
+			resp.Options.Update(dhcpv4.OptBootFileName("ipxe-x86_64.efi"))
+			return resp, true
+		case iana.EFI_ARM32:
+			// iPXE EFI 32-bit ARM bootloader
+			resp.Options.Update(dhcpv4.OptBootFileName("ipxe-arm32.efi"))
+			return resp, true
+		case iana.EFI_ARM64:
+			// iPXE EFI 64-bit ARM bootloader
+			resp.Options.Update(dhcpv4.OptBootFileName("ipxe-arm64.efi"))
 			return resp, true
 		default:
 			l.Errorf("no iPXE bootloader available for unknown architecture: %d (%s)", carch, carch.String())


### PR DESCRIPTION
OpenCHAMI uses https://github.com/OpenCHAMI/ipxe-binaries/ for iPXE binaries now. This PR:

- Sets the boot file paths to correspond with the names of these generated files based on the DHCP client architecture presented
- Sets DHCP option 17 to populate iPXE's `${root-path}` variable (see [this](https://github.com/OpenCHAMI/ipxe-binaries/blob/8e2c8fdfcf73d8c9f1775c2231802cd420419db0/config/init.ipxe#L4) line).
- Fixes assignment of legacy x86 bootloader (undionly.kpxe) to the correct architecture.