### PR TITLE
bootloop: Add built-in reboot script, ability to specify alternate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,19 +209,16 @@ configured in the CoreDHCP config file.
 
 ### Preparation: TFTP
 
-Neither CoreDHCP nor this plugin provide TFTP capability, so a separate TFTP
-server is required to be running[^tftp]. The IP address that this server listens
-on should match the `server_id` directive in the CoreDHCP config file. This
-server should serve the following files:
+With default configuration, no preparation is needed.
 
-- `reboot.ipxe` --- This file is located `resources/` in this repository.
-- `ipxe.efi` --- The iPXE x86\_64 EFI bootloader. This can be found
-  [here](https://boot.ipxe.org/ipxe.efi).
-- `undionly.kpxe` --- The iPXE x86 legacy bootloader. This can be found
-  [here](https://boot.ipxe.org/undionly.kpxe).
+Coresmd comes with a built-in TFTP server that includes iPXE bootloader binaries
+for 32-/64-bit x86/ARM (EFI) and legacy x86 CPU architectures.
 
-[^tftp]: [Here](https://github.com/aguslr/docker-atftpd) is one that is easy to
-    get running.
+When using the bootloop plugin, if the boot script path is set to "default" (see
+example config file), then the built-in reboot iPXE script is used for unknown
+nodes. This can be changed to a path in TFTP to an alternate custom iPXE boot
+script if different functionality is desired. Of course, whatever path is
+specified must exist on the TFTP server.
 
 ### Running CoreDHCP
 

--- a/bootloop/main.go
+++ b/bootloop/main.go
@@ -193,6 +193,7 @@ func (p *PluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) 
 				dhcpv4.WithMessageType(dhcpv4.MessageTypeNak),
 				dhcpv4.WithTransactionID(req.TransactionID),
 				dhcpv4.WithHwAddr(req.ClientHWAddr),
+				dhcpv4.WithServerIP(resp.ServerIPAddr),
 			)
 			if err != nil {
 				log.Errorf("failed to create new %s message: %w", dhcpv4.MessageTypeNak, err)

--- a/bootloop/main.go
+++ b/bootloop/main.go
@@ -41,10 +41,11 @@ type PluginState struct {
 var log = logger.GetLogger("plugins/bootloop")
 
 var (
-	ipv4Start net.IP
-	ipv4End   net.IP
-	ipv4Range int
-	p         PluginState
+	ipv4Start  net.IP
+	ipv4End    net.IP
+	ipv4Range  int
+	p          PluginState
+	scriptPath string
 )
 
 var Plugin = plugins.Plugin{
@@ -61,8 +62,8 @@ func setup4(args ...string) (handler.Handler4, error) {
 	log.Infof("initializing coresmd/bootloop %s (%s), built %s", version.Version, version.GitCommit, version.BuildTime)
 
 	// Ensure all required args were passed
-	if len(args) != 4 {
-		return nil, fmt.Errorf("wanted 4 arguments (file name, lease duration, IPv4 range start, IPv4 range end), got %d", len(args))
+	if len(args) != 5 {
+		return nil, fmt.Errorf("wanted 5 arguments (file name, iPXE script path, lease duration, IPv4 range start, IPv4 range end), got %d", len(args))
 	}
 	var err error
 
@@ -73,20 +74,26 @@ func setup4(args ...string) (handler.Handler4, error) {
 		return nil, fmt.Errorf("file path cannot be empty")
 	}
 
+	// Parse boot script path
+	scriptPath = args[1]
+	if filename == "" {
+		return nil, fmt.Errorf("script path cannot be empty; use 'default' if unsure")
+	}
+
 	// Parse short lease duration
-	p.LeaseTime, err = time.ParseDuration(args[1])
+	p.LeaseTime, err = time.ParseDuration(args[2])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse short lease duration %q: %w", args[0], err)
 	}
 
 	// Parse start IP
-	ipv4Start := net.ParseIP(args[2])
+	ipv4Start := net.ParseIP(args[3])
 	if ipv4Start.To4() == nil {
 		return nil, fmt.Errorf("invalid IPv4 address for range start: %s", args[1])
 	}
 
 	// Parse end IP
-	ipv4End := net.ParseIP(args[3])
+	ipv4End := net.ParseIP(args[4])
 	if ipv4End.To4() == nil {
 		return nil, fmt.Errorf("invalid IPv4 address for range end: %s", args[2])
 	}
@@ -173,7 +180,7 @@ func (p *PluginState) Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) 
 	} else {
 		if string(cinfo) == "iPXE" {
 			// BOOT STAGE 2: Send URL to BSS boot script
-			resp.Options.Update(dhcpv4.OptBootFileName("reboot.ipxe"))
+			resp.Options.Update(dhcpv4.OptBootFileName(scriptPath))
 			resp.YourIPAddr = record.IP
 			resp.Options.Update(dhcpv4.OptIPAddressLeaseTime(p.LeaseTime.Round(time.Second)))
 		} else {

--- a/coresmd/tftp.go
+++ b/coresmd/tftp.go
@@ -17,8 +17,8 @@ reboot
 type ScriptReader struct{}
 
 func (sr ScriptReader) Read(b []byte) (int, error) {
-	b = []byte(defaultScript)
-	return len(b), nil
+	nBytes := copy(b, []byte(defaultScript))
+	return nBytes, io.EOF
 }
 
 func startTFTPServer(directory string) {

--- a/resources/config.example.yaml
+++ b/resources/config.example.yaml
@@ -84,8 +84,12 @@ server4:
     # ARGUMENTS:
     #   1. Path to database file that keeps track of leased IPs. This will be
     #      created if it does not already exist.
-    #   2. Lease duration.
-    #   3. IP address beginning range.
-    #   4. IP address ending range.
+    #   2. Path of iPXE to use. If using the built-in coresmd TFTP server, if
+    #      this argument is 'default', the default reboot.ipxe script is used.
+    #      This should really only be used if it is desired to do something
+    #      custom instead of rebooting.
+    #   3. Lease duration.
+    #   4. IP address beginning range.
+    #   5. IP address ending range.
     #
-    - bootloop: /tmp/coredhcp.db 5m 172.16.0.156 172.16.0.200
+    - bootloop: /tmp/coredhcp.db default 5m 172.16.0.156 172.16.0.200

--- a/resources/reboot.ipxe
+++ b/resources/reboot.ipxe
@@ -1,2 +1,0 @@
-#!ipxe
-reboot


### PR DESCRIPTION
Currently, the bootloop plugin relies on an external `reboot.ipxe` file to present on the TFTP server. However, it would make more sense to have a reboot iPXE script be built into the binary and provide the ability to specify a different iPXE script file if different functionality is desired.

Having an internal TFTP server simplifies this. The way it works is if "default" is set as the boot file, the default reboot iPXE script:
```ipxe
#!ipxe
reboot
```
is returned. Otherwise, whatever is set for that argument is used as the boot file, and the TFTP server will search for that path in its storage.

An example bootloop configuration using the default reboot script is:
```yaml
- bootloop: /tmp/coredhcp.db default 5m 172.16.0.156 172.16.0.200
```
The same example replacing the default reboot script with a custom `test.ipxe` script is:
```yaml
- bootloop: /tmp/coredhcp.db test.ipxe 5m 172.16.0.156 172.16.0.200
```