### PR TITLE
fix: printing of version info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,18 +19,17 @@ builds:
       - v3
 
     # If you want to build this locally, you can set the following environment variables:
-    # export GIT_STATE=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)
     # export BUILD_HOST=$(hostname)
     # export GO_VERSION=$(go version | awk '{print $3}')
     # export BUILD_USER=$(whoami)
     ldflags:
       - "-s -w \
-         -X github.com/OpenCHAMI/coresmd/internal/version.GitCommit={{.Commit}} \
-         -X github.com/OpenCHAMI/coresmd/internal/version.BuildTime={{.Timestamp}} \
-         -X github.com/OpenCHAMI/coresmd/internal/version.Version={{.Version}} \
-         -X github.com/OpenCHAMI/coresmd/internal/version.GitBranch={{.Branch}} \
-         -X github.com/OpenCHAMI/coresmd/internal/version.GitTag={{.Tag}} \
-         -X github.com/OpenCHAMI/coresmd/internal/version.GitState={{ .Env.GIT_STATE }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitCommit={{ .Commit }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.BuildTime={{ .Date }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.Version={{ .Version }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitBranch={{ .Branch }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitTag={{ .Tag }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitState={{ .GitTreeState }} \
          -X github.com/OpenCHAMI/coresmd/internal/version.BuildHost={{ .Env.BUILD_HOST }} \
          -X github.com/OpenCHAMI/coresmd/internal/version.GoVersion={{ .Env.GO_VERSION }} \
          -X github.com/OpenCHAMI/coresmd/internal/version.BuildUser={{ .Env.BUILD_USER }} "

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,15 +24,16 @@ builds:
     # export GO_VERSION=$(go version | awk '{print $3}')
     # export BUILD_USER=$(whoami)
     ldflags:
-      - "-s -w -X main.GitCommit={{.Commit}} \
-         -X main.BuildTime={{.Timestamp}} \
-         -X main.Version={{.Version}} \
-         -X main.GitBranch={{.Branch}} \
-         -X main.GitTag={{.Tag}} \
-         -X main.GitState={{ .Env.GIT_STATE }} \
-         -X main.BuildHost={{ .Env.BUILD_HOST }} \
-         -X main.GoVersion={{ .Env.GO_VERSION }} \
-         -X main.BuildUser={{ .Env.BUILD_USER }} "
+      - "-s -w \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitCommit={{.Commit}} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.BuildTime={{.Timestamp}} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.Version={{.Version}} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitBranch={{.Branch}} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitTag={{.Tag}} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GitState={{ .Env.GIT_STATE }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.BuildHost={{ .Env.BUILD_HOST }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.GoVersion={{ .Env.GO_VERSION }} \
+         -X github.com/OpenCHAMI/coresmd/internal/version.BuildUser={{ .Env.BUILD_USER }} "
     binary: coredhcp
     env:
       # The bootloop plugin uses sqlite3 which requires CGO.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ using GoReleaser.
 To include detailed build metadata, ensure the following environment variables
 are set:
 
-* __GIT_STATE__: Indicates whether there are uncommitted changes in the working
-  directory. Set to clean if the repository is clean, or dirty if there are
-uncommitted changes.
 * __BUILD_HOST__: The hostname of the machine where the build is being
   performed.
 * __GO_VERSION__: The version of Go used for the build. GoReleaser uses this to

--- a/bootloop/main.go
+++ b/bootloop/main.go
@@ -56,19 +56,7 @@ var Plugin = plugins.Plugin{
 
 func logVersion() {
 	log.Infof("initializing coresmd/bootloop %s (%s), built %s", version.Version, version.GitState, version.BuildTime)
-	log.WithFields(map[string]interface{}{
-		"version": version.Version,
-		"tag": version.GitTag,
-		"commit": version.GitCommit,
-		"branch": version.GitBranch,
-		"state": version.GitState,
-		"build_timestamp": version.BuildTime,
-		"build_host": version.BuildHost,
-		"build_user": version.BuildUser,
-		"go_version": version.GoVersion,
-		"arch": version.Arch,
-		"os": version.Os,
-	}).Debugln("detailed version info")
+	log.WithFields(version.VersionInfo).Debugln("detailed version info")
 }
 
 func setup6(args ...string) (handler.Handler6, error) {

--- a/bootloop/main.go
+++ b/bootloop/main.go
@@ -54,12 +54,30 @@ var Plugin = plugins.Plugin{
 	Setup4: setup4,
 }
 
+func logVersion() {
+	log.Infof("initializing coresmd/bootloop %s (%s), built %s", version.Version, version.GitState, version.BuildTime)
+	log.WithFields(map[string]interface{}{
+		"version": version.Version,
+		"tag": version.GitTag,
+		"commit": version.GitCommit,
+		"branch": version.GitBranch,
+		"state": version.GitState,
+		"build_timestamp": version.BuildTime,
+		"build_host": version.BuildHost,
+		"build_user": version.BuildUser,
+		"go_version": version.GoVersion,
+		"arch": version.Arch,
+		"os": version.Os,
+	}).Debugln("detailed version info")
+}
+
 func setup6(args ...string) (handler.Handler6, error) {
+	logVersion()
 	return nil, errors.New("bootloop does not currently support DHCPv6")
 }
 
 func setup4(args ...string) (handler.Handler4, error) {
-	log.Infof("initializing coresmd/bootloop %s (%s), built %s", version.Version, version.GitCommit, version.BuildTime)
+	logVersion()
 
 	// Ensure all required args were passed
 	if len(args) != 5 {

--- a/coresmd/main.go
+++ b/coresmd/main.go
@@ -49,19 +49,7 @@ const (
 
 func logVersion() {
 	log.Infof("initializing coresmd/coresmd %s (%s), built %s", version.Version, version.GitState, version.BuildTime)
-	log.WithFields(map[string]interface{}{
-		"version": version.Version,
-		"tag": version.GitTag,
-		"commit": version.GitCommit,
-		"branch": version.GitBranch,
-		"state": version.GitState,
-		"build_timestamp": version.BuildTime,
-		"build_host": version.BuildHost,
-		"build_user": version.BuildUser,
-		"go_version": version.GoVersion,
-		"arch": version.Arch,
-		"os": version.Os,
-	}).Debugln("detailed version info")
+	log.WithFields(version.VersionInfo).Debugln("detailed version info")
 }
 
 func setup6(args ...string) (handler.Handler6, error) {

--- a/coresmd/main.go
+++ b/coresmd/main.go
@@ -47,12 +47,29 @@ const (
 	defaultTFTPPort      = 69
 )
 
+func logVersion() {
+	log.Infof("initializing coresmd/coresmd %s (%s), built %s", version.Version, version.GitState, version.BuildTime)
+	log.WithFields(map[string]interface{}{
+		"version": version.Version,
+		"tag": version.GitTag,
+		"commit": version.GitCommit,
+		"branch": version.GitBranch,
+		"state": version.GitState,
+		"build_timestamp": version.BuildTime,
+		"build_host": version.BuildHost,
+		"build_user": version.BuildUser,
+		"go_version": version.GoVersion,
+		"arch": version.Arch,
+		"os": version.Os,
+	}).Debugln("detailed version info")
+}
+
 func setup6(args ...string) (handler.Handler6, error) {
 	return nil, errors.New("coresmd does not currently support DHCPv6")
 }
 
 func setup4(args ...string) (handler.Handler4, error) {
-	log.Infof("initializing coresmd/coresmd %s (%s), built %s", version.Version, version.GitCommit, version.BuildTime)
+	logVersion()
 
 	// Ensure all required args were passed
 	if len(args) != 6 {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,9 +1,6 @@
 package version
 
-import (
-	"fmt"
-	"runtime"
-)
+import "runtime"
 
 // GitCommit stores the latest Git commit hash.
 // Set via -ldflags "-X main.GitCommit=$(git rev-parse HEAD)"
@@ -51,20 +48,17 @@ var Arch string = runtime.GOARCH
 // OS the running binary was built for.
 var Os string = runtime.GOOS
 
-// PrintVersionInfo outputs all versioning information for troubleshooting or version checks.
-func PrintVersionInfo() {
-	fmt.Printf("Version: %s\n", Version)
-	fmt.Printf("Git Commit: %s\n", GitCommit)
-	fmt.Printf("Build Time: %s\n", BuildTime)
-	fmt.Printf("Git Branch: %s\n", GitBranch)
-	fmt.Printf("Git Tag: %s\n", GitTag)
-	fmt.Printf("Git State: %s\n", GitState)
-	fmt.Printf("Build Host: %s\n", BuildHost)
-	fmt.Printf("Go Version: %s\n", GoVersion)
-	fmt.Printf("Build User: %s\n", BuildUser)
-}
-
-func VersionInfo() string {
-	return fmt.Sprintf("Version: %s, Git Commit: %s, Build Time: %s, Git Branch: %s, Git Tag: %s, Git State: %s, Build Host: %s, Go Version: %s, Build User: %s",
-		Version, GitCommit, BuildTime, GitBranch, GitTag, GitState, BuildHost, GoVersion, BuildUser)
+// VersionInfo is all of the fields above combined into a map to be logged.
+var VersionInfo = map[string]interface{}{
+	"version":         Version,
+	"tag":             GitTag,
+	"commit":          GitCommit,
+	"branch":          GitBranch,
+	"state":           GitState,
+	"build_timestamp": BuildTime,
+	"build_host":      BuildHost,
+	"build_user":      BuildUser,
+	"go_version":      GoVersion,
+	"arch":            Arch,
+	"os":              Os,
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+)
 
 // GitCommit stores the latest Git commit hash.
 // Set via -ldflags "-X main.GitCommit=$(git rev-parse HEAD)"
@@ -38,6 +41,15 @@ var GoVersion string
 // BuildUser is the username of the person or system that initiated the build process.
 // Set via -ldflags "-X main.BuildUser=$(whoami)"
 var BuildUser string
+
+// Compiler that built the running binary.
+var Compiler string = runtime.Compiler
+
+// CPU architecture of the running binary.
+var Arch string = runtime.GOARCH
+
+// OS the running binary was built for.
+var Os string = runtime.GOOS
 
 // PrintVersionInfo outputs all versioning information for troubleshooting or version checks.
 func PrintVersionInfo() {


### PR DESCRIPTION
Version info was not getting set correctly in Goreleaser and therefore was not being printed upon plugin initialization. This PR corrects this, as well as:

- Prints a summary of version info at info logging level upon plugin init
- Prints detailed version info at debug level upon plugin init (i.e. when CoreDHCP is run with `-L debug`)
- Formats the detailed version info as log message fields to align with CoreDHCP logging standard
- Adds compiler, CPU architecture, and OS information to the detailed version info

This allows more information to be available when troubleshooting.

The following represents example logging output when debugging is enabled:

```
[...]
time="2025-01-08T18:22:38Z" level=info msg="initializing coresmd/coresmd 0.2.1-SNAPSHOT-e6a18e4 (dirty), built 2025-01-08T18:09:41Z" prefix="plugins/coresmd"                                               
time="2025-01-08T18:22:38Z" level=debug msg="detailed version info" arch=amd64 branch="synackd/fix-version" build_host=ochami-vm build_timestamp="2025-01-08T18:09:41Z" build_user=root commit=e6a18e4ef5ee108ee46e4770dc20f5709ab0bf60 go_version=go1.23.2 os=linux prefix="plugins/coresmd" state=dirty tag=v0.2.1 version=0.2.1-SNAPSHOT-e6a18e4 
[...]
time="2025-01-08T18:22:38Z" level=info msg="initializing coresmd/bootloop 0.2.1-SNAPSHOT-e6a18e4 (dirty), built 2025-01-08T18:09:41Z" prefix="plugins/bootloop"                                             
time="2025-01-08T18:22:38Z" level=debug msg="detailed version info" arch=amd64 branch="synackd/fix-version" build_host=ochami-vm build_timestamp="2025-01-08T18:09:41Z" build_user=root commit=e6a18e4ef5ee108ee46e4770dc20f5709ab0bf60 go_version=go1.23.2 os=linux prefix="plugins/bootloop" state=dirty tag=v0.2.1 version=0.2.1-SNAPSHOT-e6a18e4
[...]
```