### PR TITLE
build(docker): add dhcping to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM chainguard/wolfi-base:latest
 # Include curl and tini in the final image.
 RUN set -ex \
     && apk update \
-    && apk add --no-cache curl tini jq \
+    && apk add --no-cache curl tini jq dhcping \
     && rm -rf /var/cache/apk/*  \
     && rm -rf /tmp/*
 


### PR DESCRIPTION
closes #22 

Used for healthchecks, e.g:

```
dhcping -qs <dhcp_server_address> -c <dhcp_server_address>
```