### PR TITLE
ci: use GitHub release notes and release as draft

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -26,6 +26,11 @@ jobs:
           fetch-tags: 1
           fetch-depth: 1
 
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" -F tag_name="${{ github.ref_name }}" --jq .body > ../notes.md
+
       # Set environment variables required by GoReleaser
       - name: Set build environment variables
         run: |
@@ -43,10 +48,10 @@ jobs:
       - name: Release with goreleaser
         uses: goreleaser/goreleaser-action@v6
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: '~> v2'
-          args: release --clean
+          args: release --clean --release-notes ../notes.md
         id: goreleaser
 
       - name: Process goreleaser output

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -100,3 +100,9 @@ docker_manifests:
       - *amd64_linux_image
       - *arm64v8_linux_image
 
+release:
+  github:
+  draft: true
+  name_template: "v{{ .Version }}"
+  prerelease: auto
+  mode: replace


### PR DESCRIPTION
GitHub handles merge commits and including PR information in release notes than Goreleaser. Draft releases allow editing before release if this is not sufficient.