### PR TITLE
feat(coresmd/coredhcp): add per-rule netmask action (and fixes/docs updates)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,11 +136,11 @@ goreleaser-clean: ## Clean Goreleaser files (remove dist/)
 	$(RM) -rf dist/
 
 .PHONY: check-reuse
-check-reuse:
+check-reuse: ## Check REUSE compliance
 ifeq ($(REUSE),)
 	$(error reuse command not found)
 endif
-	reuse lint
+	reuse lint --lines
 
 .PHONY: lint
 lint:

--- a/examples/coredhcp/rules.md
+++ b/examples/coredhcp/rules.md
@@ -5,11 +5,14 @@ SPDX-FileCopyrightText: © 2026 OpenCHAMI a Series of LF Projects, LLC
 SPDX-License-Identifier: MIT
 -->
 
-# Rules for the CoreSMD CoreDHCP Plugin (Hostnames and Routers)
+# Rich Rules for the CoreSMD CoreDHCP Plugin
+
+Rich rules allow specifying various DHCP options for certain machines using
+match filters.
 
 ## Contents
 
-- [Rules for the CoreSMD CoreDHCP Plugin (Hostnames and Routers)](#rules-for-the-coresmd-coredhcp-plugin-hostnames-and-routers)
+- [Rich Rules for the CoreSMD CoreDHCP Plugin](#rich-rules-for-the-coresmd-coredhcp-plugin)
   - [Contents](#contents)
   - [Quick Start](#quick-start)
   - [Summary](#summary)
@@ -71,7 +74,7 @@ In a CoreDHCP configuration:
 ## Summary
 
 CoreSMD can set various DHCP options (e.g. hostname (option 12), routers (option
-3)) using an ordered list of rules. Each rule matches on SMD inventory
+3), etc.) using an ordered list of rules. Each rule matches on SMD inventory
 attributes (component type, component ID, and the assigned IP address) and sets
 the appropriate DHCP options based on the actions defined in the rule.
 
@@ -230,7 +233,8 @@ legacy `pattern` key. See [Pattern Syntax](#pattern-syntax) above.
 #### `routers:IP[|IP...]`
 
 Set DHCPv4 Router option (RFC 2132 option 3) for the matched host. Multiple
-routers may be specified using `|`.
+routers may be specified using `|`. This action will override any routers set
+with the CoreDHCP `netmask` plugin.
 
 This action applies to DHCPv4 only.
 

--- a/examples/coredhcp/rules.md
+++ b/examples/coredhcp/rules.md
@@ -33,6 +33,8 @@ match filters.
     - [Action Keys](#action-keys)
       - [`hostname:PATTERN`](#hostnamepattern)
       - [`routers:IP[|IP...]`](#routersipip)
+      - [`netmask:MASK`](#netmaskmask)
+      - [`cidr:BITS`](#cidrbits)
       - [`domain:DOMAIN`](#domaindomain-1)
       - [`domain_append:MODE`](#domain_appendmode)
       - [`continue:{true|false}`](#continuetruefalse)
@@ -45,9 +47,10 @@ match filters.
     - [3. Per-type rules](#3-per-type-rules)
     - [4. Subnet-specific BMC naming](#4-subnet-specific-bmc-naming)
     - [5. Per-subnet routers (DHCPv4 option 3)](#5-per-subnet-routers-dhcpv4-option-3)
-    - [6. Suppress domain suffix for selected hosts](#6-suppress-domain-suffix-for-selected-hosts)
-    - [7. Hostname override with `continue`](#7-hostname-override-with-continue)
-    - [8. Familiar "legacy-style" configuration, expressed as rules](#8-familiar-legacy-style-configuration-expressed-as-rules)
+    - [6. Netmask and CIDR (DHCPv4 option 1)](#6-netmask-and-cidr-dhcpv4-option-1)
+    - [7. Suppress domain suffix for selected hosts](#7-suppress-domain-suffix-for-selected-hosts)
+    - [8. Hostname override with `continue`](#8-hostname-override-with-continue)
+    - [9. Familiar "legacy-style" configuration, expressed as rules](#9-familiar-legacy-style-configuration-expressed-as-rules)
   - [Caveats](#caveats)
   - [See Also](#see-also)
 
@@ -74,7 +77,7 @@ In a CoreDHCP configuration:
 ## Summary
 
 CoreSMD can set various DHCP options (e.g. hostname (option 12), routers (option
-3), etc.) using an ordered list of rules. Each rule matches on SMD inventory
+3), netmask (option 1), etc.) using an ordered list of rules. Each rule matches on SMD inventory
 attributes (component type, component ID, and the assigned IP address) and sets
 the appropriate DHCP options based on the actions defined in the rule.
 
@@ -108,7 +111,11 @@ Controls rule logging.
 
 Add a rule. May be specified multiple times. **Order matters!**
 
-A rule may set a hostname (DHCP option 12) and/or routers (DHCPv4 option 3).
+A rule may set:
+
+- `hostname` (DHCP option 12)
+- `routers` (DHCPv4 option 3)
+- `netmask` (DHCPv4 option 1)
 
 ## Migrating from `*_pattern`
 
@@ -194,9 +201,13 @@ one type.
 
 #### `subnet:CIDR[|CIDR...]`
 
-Match assigned IP against one or more CIDRs. **Only the first IP is
-matched** because CoreDHCP only assigns one address to the interface and it is
-assumed that the first IP address in the list is the desired one.
+Match assigned IP against one or more CIDRs. If a component in SMD has more
+than one IP address assigned, **only the first IP in the list is matched
+against `subnet`** because CoreDHCP only assigns one address to the interface
+and it is assumed that the first IP address in the list is the desired one.
+
+`subnet` is the only match key that can also serve as an action key. See
+[`netmask:MASK`](#netmaskmask) and [`cidr:BITS`](#cidrbits).
 
 **Default:** omitted (matches any subnet)
 
@@ -220,8 +231,8 @@ Mutually exclusive with `id`.
 ### Action Keys
 
 Rules may apply one or more actions when matched. At least one action must be
-specified. If no match keys are specified, the action(s) will apply to all
-incoming DHCP requests.
+specified (`hostname`, `routers`, `netmask`, or `cidr`). If no match keys are
+specified, the action(s) will apply to all incoming DHCP requests.
 
 #### `hostname:PATTERN`
 
@@ -232,13 +243,49 @@ legacy `pattern` key. See [Pattern Syntax](#pattern-syntax) above.
 
 #### `routers:IP[|IP...]`
 
-Set DHCPv4 Router option (RFC 2132 option 3) for the matched host. Multiple
-routers may be specified using `|`. This action will override any routers set
-with the CoreDHCP `netmask` plugin.
+Set DHCPv4 Router option (RFC 2132 option 3) for the matched host. Values must
+be IPv4 addresses. Multiple routers may be specified using `|`. This action
+will override any routers set with the CoreDHCP `netmask` plugin.
 
 This action applies to DHCPv4 only.
 
 **Default:** omitted (no routers set by this rule)
+
+#### `netmask:MASK`
+
+Set DHCPv4 Subnet Mask option (RFC 2132 option 1) for the matched host. The
+mask must be a valid IPv4 network mask (contiguous 1-bits), for example:
+
+- `255.255.255.0`
+- `255.255.252.0`
+
+This action applies to DHCPv4 only.
+
+Mutually exclusive with `cidr`.
+
+If a rule uses the `subnet` match key and neither `netmask` nor `cidr` is
+specified, CoreSMD sets the DHCPv4 Subnet Mask option to the mask of the **first
+subnet** in the rule.
+
+**Default:** omitted
+
+#### `cidr:BITS`
+
+Set DHCPv4 Subnet Mask option (RFC 2132 option 1) for the matched host by CIDR
+width, where `BITS` is an integer from 1 to 32 (inclusive), for example:
+
+- `24` (equivalent to `255.255.255.0`)
+- `21` (equivalent to `255.255.248.0`)
+
+This action applies to DHCPv4 only.
+
+Mutually exclusive with `netmask`.
+
+If a rule uses the `subnet` match key and neither `netmask` nor `cidr` is
+specified, CoreSMD sets the DHCPv4 Subnet Mask option to the mask of the **first
+subnet** in the rule.
+
+**Default:** omitted
 
 #### `domain:DOMAIN`
 
@@ -417,7 +464,35 @@ to DHCP option 3 for matching DHCPv4 clients.
 | 172.16.1.10 | Node | 7 | `nid0007.lab.local` | `172.16.1.1`, `172.16.1.2` |
 | 172.16.9.10 | Node | 7 | `nid0007.lab.local` | `172.16.0.1` |
 
-### 6. Suppress domain suffix for selected hosts
+### 6. Netmask and CIDR (DHCPv4 option 1)
+
+Use `netmask:` or `cidr:` to set the DHCPv4 subnet mask (option 1).
+
+If a rule uses `subnet:` as a match key and neither `netmask` nor `cidr` is
+specified, CoreSMD sets option 1 to the mask of the **first subnet** in the
+rule.
+
+```yaml
+- coresmd: |
+    domain=lab.local
+
+    /* Explicit mask */
+    rule=name:mask,type:Node,hostname:nid{04d},netmask:255.255.255.0
+
+    /* Explicit CIDR */
+    rule=name:cidr,type:NodeBMC,hostname:bmc{04d},cidr:26
+
+    /* Implicit mask from subnet (first subnet only) */
+    rule=name:implicit,type:Node,subnet:172.16.0.0/21|172.16.8.0/21,hostname:nid{04d}
+```
+
+| Rule | Type | IP (assigned) | Hostname | Netmask (option 1) |
+|---|---|---:|---|---|
+| `mask` | Node | 172.16.0.10 | `nid0007.lab.local` | `255.255.255.0` |
+| `cidr` | NodeBMC | 172.16.0.10 | `bmc0007.lab.local` | `255.255.255.192` |
+| `implicit` | Node | 172.16.0.10 | `nid0007.lab.local` | `255.255.248.0` |
+
+### 7. Suppress domain suffix for selected hosts
 
 Use `domain_append:none` in the rule action. This suppresses all domain
 suffixing, regardless of global `domain` and regardless of other
@@ -439,7 +514,7 @@ Use `domain_append:none` to suppress suffixing.
 | 1 | Node | `nid0001.cluster.local` |
 | 1 | NodeBMC | `bmc0001` |
 
-### 7. Hostname override with `continue`
+### 8. Hostname override with `continue`
 
 `continue:true` allows later rules to refine/override hostnames.
 
@@ -462,7 +537,7 @@ the second overrides the domain for that subnet.
 | 172.16.0.10 | Node | 7 | `nid0007.mgmt.local` |
 | 172.16.9.10 | Node | 7 | `nid0007.cluster.local` |
 
-### 8. Familiar "legacy-style" configuration, expressed as rules
+### 9. Familiar "legacy-style" configuration, expressed as rules
 
 The old `node_pattern`, `bmc_pattern`, `hostname_by_type`, and
 `hostname_default` directives are replaced by `rule`.
@@ -489,7 +564,8 @@ while preserving rule ordering and allowing additional matching criteria.
 
 ## Caveats
 
-- At least one action must be specified: `hostname` and/or `routers`.
+- At least one action must be specified: `hostname`, `routers`, `netmask`, or `cidr`.
+  (Note: `subnet` may implicitly set a netmask when neither `netmask` nor `cidr` is specified.)
 - `type:` is optional, but if present must include at least one type.
 - Only the first assigned IP is used for subnet matching.
 - `domain_append:none` suppresses all domain suffixing.

--- a/internal/rule/errors.go
+++ b/internal/rule/errors.go
@@ -87,6 +87,8 @@ func (ebq ErrBadQuote) Error() string {
 	return fmt.Sprintf("element %d: bad quoting: %v: got %q", ebq.Elem, ebq.QuoteErr, ebq.Got)
 }
 
+// ErrDuplicateKey represents an error that occurs when a duplicate key is
+// specified.
 type ErrDuplicateKey struct {
 	Elem int
 	Got  string
@@ -105,6 +107,8 @@ func (edk ErrDuplicateKey) Error() string {
 	return fmt.Sprintf("element %d: duplicate key %q: got %q", edk.Elem, edk.Key, edk.Got)
 }
 
+// ErrRequiredKeys represents an error that occurs when one or more required
+// keys are not specified.
 type ErrRequiredKeys struct {
 	Keys []string
 }
@@ -119,6 +123,9 @@ func (erk ErrRequiredKeys) Error() string {
 	return fmt.Sprintf("required key missing, at least one of %v", erk.Keys)
 }
 
+// ErrInvalidValue represents an error where a key has an unexpected value. A
+// string representing the expected value is stored as well to be printed in the
+// error.
 type ErrInvalidValue struct {
 	Key      string
 	Value    string
@@ -137,6 +144,8 @@ func (eiv ErrInvalidValue) Error() string {
 	return fmt.Sprintf("invalid value for key %q (expected %s but got %q)", eiv.Key, eiv.Expected, eiv.Value)
 }
 
+// ErrMutualExclusion represents an error where two or more mutually-exclusive
+// keys were specified.
 type ErrMutualExclusion struct {
 	Keys []string
 }

--- a/internal/rule/errors_test.go
+++ b/internal/rule/errors_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package rule
+
+import "testing"
+
+func TestErrors_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"keyval_format", NewErrKeyValFormat(3, "bogus"), "element 3: expected key:val, got \"bogus\""},
+		{"no_key", NewErrNoKey(2, ":x"), "element 2: empty key (got \":x\")"},
+		{"unknown_key", NewErrUnknownKey(1, "domian"), "element 1: unknown key \"domian\""},
+		{"duplicate_key", NewErrDuplicateKey(4, "hostname:x", "hostname"), "element 4: duplicate key \"hostname\": got \"hostname:x\""},
+		{"required_keys", NewErrRequiredKeys("hostname", "routers"), "required key missing, at least one of [hostname routers]"},
+		{"invalid_value", NewErrInvalidValue("domain_append", "maybe", "global|rule|none"), "invalid value for key \"domain_append\" (expected global|rule|none but got \"maybe\")"},
+		{"mutual_exclusion", NewErrMutualExclusion("netmask", "cidr"), "keys are mutually exclusive: [netmask cidr]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Fatalf("expected=%q got=%q", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/rule/hostname_test.go
+++ b/internal/rule/hostname_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package rule
+
+import (
+	"net"
+	"testing"
+
+	"github.com/openchami/coresmd/internal/iface"
+)
+
+func TestLookupHostname_DomainAppendModes(t *testing.T) {
+	ii := iface.IfaceInfo{CompID: "x1000s0c0b0n0", CompNID: 7, Type: "Node", MAC: "aa", IPList: []net.IP{net.ParseIP("172.16.0.10")}}
+
+	tests := []struct {
+		name      string
+		globalDom string
+		rule      Rule
+		want      string
+	}{
+		{
+			name:      "default_global_only",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}"}},
+			want:      "nid0007.cluster.local",
+		},
+		{
+			name:      "default_rule_overrides_global",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local"}},
+			want:      "nid0007.override.local",
+		},
+		{
+			name:      "explicit_global",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "global"}},
+			want:      "nid0007.cluster.local",
+		},
+		{
+			name:      "explicit_rule",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "rule"}},
+			want:      "nid0007.override.local",
+		},
+		{
+			name:      "explicit_global_rule",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "global|rule"}},
+			want:      "nid0007.cluster.local.override.local",
+		},
+		{
+			name:      "explicit_rule_global_order_matters",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "rule|global"}},
+			want:      "nid0007.override.local.cluster.local",
+		},
+		{
+			name:      "explicit_none",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "none"}},
+			want:      "nid0007",
+		},
+		{
+			name:      "explicit_rule_without_rule_domain",
+			globalDom: "cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", DomainAppend: "rule"}},
+			want:      "nid0007",
+		},
+		{
+			name:      "leading_dots_trimmed",
+			globalDom: ".cluster.local",
+			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: ".override.local", DomainAppend: "global|rule"}},
+			want:      "nid0007.cluster.local.override.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lookupHostname(tt.rule.Action.Hostname, tt.globalDom, ii, tt.rule)
+			if got != tt.want {
+				t.Fatalf("expected=%q got=%q", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/rule/netmask.go
+++ b/internal/rule/netmask.go
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: Copyright 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package rule
+
+import (
+	"encoding/binary"
+	"net"
+)
+
+// Taken from:
+// https://github.com/coredhcp/coredhcp/blob/a0841cb3038f63e3f93e813648cea8641a3bc5c0/plugins/netmask/plugin.go#L57-L62
+func checkValidNetmask(netmask net.IPMask) bool {
+	netmaskInt := binary.BigEndian.Uint32(netmask)
+	x := ^netmaskInt
+	y := x + 1
+	return (y & x) == 0
+}

--- a/internal/rule/netmask_test.go
+++ b/internal/rule/netmask_test.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package rule
+
+import (
+	"net"
+	"testing"
+)
+
+func TestCheckValidNetmask_Table(t *testing.T) {
+	tests := []struct {
+		name string
+		m    net.IPMask
+		want bool
+	}{
+		{"/24", net.IPv4Mask(255, 255, 255, 0), true},
+		{"/32", net.IPv4Mask(255, 255, 255, 255), true},
+		{"/0", net.IPv4Mask(0, 0, 0, 0), true},
+		{"non_contiguous", net.IPv4Mask(255, 0, 255, 0), false},
+		{"v6_mask_contiguous", net.CIDRMask(64, 128), true},
+		{"v6_mask_non_contiguous", net.IPMask([]byte{0xff, 0x00, 0xff, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkValidNetmask(tt.m); got != tt.want {
+				t.Fatalf("expected=%v got=%v", tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -24,6 +25,7 @@ import (
 const DefaultPattern = "unknown-{04d}"
 
 var AllowedKeys = []string{
+	"cidr",
 	"continue",
 	"domain",
 	"domain_append",
@@ -32,6 +34,7 @@ var AllowedKeys = []string{
 	"id_set",
 	"log",
 	"name",
+	"netmask",
 	"routers",
 	"subnet",
 	"type",
@@ -175,11 +178,12 @@ func (m Match) String() string {
 
 // Action represents an action to take upon a rule matching
 type Action struct {
-	Hostname     string   // hostname pattern to apply
-	Domain       string   // rule-specific domain to use when generating the FQDN
-	DomainAppend string   // controls when/how to append domain to hostname (rule vs. global vs. both)
-	Routers      []net.IP // router IPs for selected component(s)
-	Continue     bool     // whether to continue parsing subsequent rules if this matches
+	Hostname     string     // hostname pattern to apply
+	Domain       string     // rule-specific domain to use when generating the FQDN
+	DomainAppend string     // controls when/how to append domain to hostname (rule vs. global vs. both)
+	Netmask      net.IPMask // rule-specific network mask for IPv4
+	Routers      []net.IP   // router IPs for selected component(s)
+	Continue     bool       // whether to continue parsing subsequent rules if this matches
 }
 
 func (a Action) String() string {
@@ -199,6 +203,11 @@ func (a Action) String() string {
 		actionStr += fmt.Sprintf(",domain_append:%s", da)
 	}
 	actionStr += fmt.Sprintf(",continue:%v", a.Continue)
+
+	// Canonicalize netmask for IPv4 to CIDR notation
+	if ones, _ := a.Netmask.Size(); ones > 0 {
+		actionStr += fmt.Sprintf(",netmask:/%d", ones)
+	}
 
 	if len(a.Routers) > 0 {
 		parts := make([]string, 0, len(a.Routers))
@@ -279,10 +288,54 @@ func ParseRule(rule string) (Rule, error) {
 		}
 	}
 
-	// At least one action is required
-	if a.Hostname == "" &&
-		len(a.Routers) == 0 {
-		return Rule{}, NewErrRequiredKeys("hostname", "routers")
+	// netmask/cidr (action)
+	netmaskstr, netmaskFound := comps["netmask"]
+	cidrstr, cidrFound := comps["cidr"]
+	if netmaskFound && cidrFound {
+		// Both netmask and cidr are not allowed, only one or the other
+		return Rule{}, NewErrMutualExclusion("netmask", "cidr")
+	} else if netmaskFound {
+		// netmask specified
+
+		// Check that mask is a valid IP
+		netmaskIP := net.ParseIP(netmaskstr)
+		if netmaskIP == nil {
+			return Rule{}, NewErrInvalidValue("netmask", netmaskstr, "valid IPv4 address")
+		}
+
+		// Check that mask is not unspecified IP like 0.0.0.0
+		if netmaskIP.IsUnspecified() {
+			return Rule{}, NewErrInvalidValue("netmask", netmaskstr, "specific, usable IPv4 address")
+		}
+
+		// Check that mask IP is a valid IPv4
+		netmaskIP = netmaskIP.To4()
+		if netmaskIP == nil {
+			return Rule{}, NewErrInvalidValue("netmask", netmaskstr, "valid IPv4 address")
+		}
+
+		// Check that mask IP is a valid IPv4 netmask
+		netmask := net.IPv4Mask(netmaskIP[0], netmaskIP[1], netmaskIP[2], netmaskIP[3])
+		if !checkValidNetmask(netmask) {
+			return Rule{}, NewErrInvalidValue("netmask", netmaskstr, "valid IPv4 netmask")
+		}
+
+		a.Netmask = netmask
+	} else if cidrFound {
+		// cidr specified
+
+		// Convert from string to integer
+		cidr, err := strconv.Atoi(cidrstr)
+		if err != nil {
+			return Rule{}, NewErrInvalidValue("cidr", cidrstr, "integer")
+		}
+
+		// Check range validity (32 bits for IPv4)
+		if cidr <= 0 || cidr > 32 {
+			return Rule{}, NewErrInvalidValue("cidr", cidrstr, "valid IPv4 bit width between 1 and 32, inclusive")
+		}
+
+		a.Netmask = net.CIDRMask(cidr, 32)
 	}
 
 	// domain override (optional)
@@ -360,6 +413,29 @@ func ParseRule(rule string) (Rule, error) {
 			} else {
 				m.Subnets = append(m.Subnets, ipnet)
 			}
+		}
+
+		// If subnet/cidr not defined, use the subnet's CIDR for it
+		if ones, size := a.Netmask.Size(); ones == 0 || size == 0 {
+			cidr, _ := m.Subnets[0].Mask.Size()
+			if cidr > 0 {
+				a.Netmask = m.Subnets[0].Mask
+			} else {
+				// Do not err if mask is 0 or invalid; fallback to already-set
+				// netmask.
+			}
+		}
+	}
+
+	// At least one action is required.
+	//
+	// Netmask can be set explicitly via netmask/cidr or implicitly from subnet.
+	// In this way, subnet can be considered an "action" and is the only match
+	// key to be considered such.
+	if strings.TrimSpace(a.Hostname) == "" &&
+		len(a.Routers) == 0 {
+		if ones, size := a.Netmask.Size(); ones == 0 || size == 0 {
+			return Rule{}, NewErrRequiredKeys("hostname", "routers", "netmask")
 		}
 	}
 
@@ -561,6 +637,25 @@ func Evaluate4(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog s
 			// Set routers
 			if len(rule.Action.Routers) > 0 {
 				resp.Options.Update(dhcpv4.OptRouter(rule.Action.Routers...))
+			}
+
+			// Set netmask (DHCP option 1)
+			//
+			// If the rule did not explicitly set a netmask/cidr action but the rule
+			// matched on subnet, implicitly set the subnet mask to the CIDR of the
+			// first subnet in the match list.
+			mask := rule.Action.Netmask
+			if ones, size := mask.Size(); ones == 0 || size == 0 {
+				if len(rule.Match.Subnets) > 0 {
+					m := rule.Match.Subnets[0].Mask
+					// Only apply IPv4 masks here (DHCPv4 option 1).
+					if len(m) == net.IPv4len {
+						mask = m
+					}
+				}
+			}
+			if ones, size := mask.Size(); ones != 0 && size != 0 {
+				resp.Options.Update(dhcpv4.OptSubnetMask(mask))
 			}
 
 			if !cont {

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -267,11 +267,15 @@ func ParseRule(rule string) (Rule, error) {
 	// router (action)
 	if rtrs, ok := comps["routers"]; ok && rtrs != "" {
 		for _, r := range strings.Split(rtrs, "|") {
-			if ip := net.ParseIP(strings.TrimSpace(r)); ip == nil {
-				return Rule{}, NewErrInvalidValue("routers", r, "valid IP address")
-			} else {
-				a.Routers = append(a.Routers, ip)
+			ip := net.ParseIP(strings.TrimSpace(r))
+			if ip == nil {
+				return Rule{}, NewErrInvalidValue("routers", r, "valid IPv4 address")
 			}
+			ip4 := ip.To4()
+			if ip4 == nil {
+				return Rule{}, NewErrInvalidValue("routers", r, "valid IPv4 address")
+			}
+			a.Routers = append(a.Routers, ip4)
 		}
 	}
 

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -79,9 +79,6 @@ func TestParseRule_Table(t *testing.T) {
 		{"continue_invalid", "hostname:x,continue:maybe", true},
 		{"domain_append_invalid", "hostname:x,domain_append:maybe", true},
 		{"domain_append_none_combo_invalid", "hostname:x,domain_append:none|rule", true},
-		{"domain_append_duplicate_global", "hostname:x,domain:override.local,domain_append:global|global", true},
-		{"domain_append_duplicate_rule", "hostname:x,domain:override.local,domain_append:rule|rule", true},
-		{"domain_append_duplicate_mixed", "hostname:x,domain:override.local,domain_append:global|rule|global", true},
 		{"domain_none_removed", "hostname:x,domain:none", true},
 		{"subnet_invalid", "hostname:x,subnet:notacidr", true},
 		{"id_and_idset_mutual_exclusion", "hostname:x,id:a,id_set:b", true},
@@ -98,13 +95,6 @@ func TestParseRule_Table(t *testing.T) {
 			}
 			if tt.wantErr {
 				return
-			}
-			// ParseRule() does not know the global rule_log value. If 'log' is
-			// omitted, it should be left empty for the caller to apply defaults.
-			if tt.name == "ok_minimal" || tt.name == "routers_only_ok" {
-				if r.Log != "" {
-					t.Fatalf("expected default rule log to be empty got=%q", r.Log)
-				}
 			}
 			if tt.name != "routers_only_ok" && r.Action.Hostname == "" {
 				t.Fatalf("expected non-empty hostname got=%q", r.Action.Hostname)
@@ -127,81 +117,6 @@ func TestParseRule_Table(t *testing.T) {
 				if r.Action.DomainAppend != "rule|global" {
 					t.Fatalf("expected domain_append=%q got=%q", "rule|global", r.Action.DomainAppend)
 				}
-			}
-		})
-	}
-}
-
-func TestLookupHostname_DomainAppendModes(t *testing.T) {
-	ii := iface.IfaceInfo{CompID: "x1000s0c0b0n0", CompNID: 7, Type: "Node", MAC: "aa", IPList: []net.IP{net.ParseIP("172.16.0.10")}}
-
-	tests := []struct {
-		name      string
-		globalDom string
-		rule      Rule
-		want      string
-	}{
-		{
-			name:      "default_global_only",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}"}},
-			want:      "nid0007.cluster.local",
-		},
-		{
-			name:      "default_rule_overrides_global",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local"}},
-			want:      "nid0007.override.local",
-		},
-		{
-			name:      "explicit_global",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "global"}},
-			want:      "nid0007.cluster.local",
-		},
-		{
-			name:      "explicit_rule",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "rule"}},
-			want:      "nid0007.override.local",
-		},
-		{
-			name:      "explicit_global_rule",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "global|rule"}},
-			want:      "nid0007.cluster.local.override.local",
-		},
-		{
-			name:      "explicit_rule_global_order_matters",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "rule|global"}},
-			want:      "nid0007.override.local.cluster.local",
-		},
-		{
-			name:      "explicit_none",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: "override.local", DomainAppend: "none"}},
-			want:      "nid0007",
-		},
-		{
-			name:      "explicit_rule_without_rule_domain",
-			globalDom: "cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", DomainAppend: "rule"}},
-			want:      "nid0007",
-		},
-		{
-			name:      "leading_dots_trimmed",
-			globalDom: ".cluster.local",
-			rule:      Rule{Action: Action{Hostname: "nid{04d}", Domain: ".override.local", DomainAppend: "global|rule"}},
-			want:      "nid0007.cluster.local.override.local",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := lookupHostname(tt.rule.Action.Hostname, tt.globalDom, ii, tt.rule)
-			if got != tt.want {
-				t.Fatalf("expected=%q got=%q", tt.want, got)
 			}
 		})
 	}

--- a/plugin/coredhcp/coresmd/main.go
+++ b/plugin/coredhcp/coresmd/main.go
@@ -454,7 +454,8 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 		"assigned_hostname": string(resp.Options.Get(dhcpv4.OptionHostName)),
 		"lease_duration":    globalConfig.leaseTime,
 		"server_ip":         resp.ServerIPAddr,
-		"router_ip":         string(resp.Options.Get(dhcpv4.OptionRouter)),
+		"router_ips":        fmt.Sprintf("%v", dhcpv4.GetIPs(dhcpv4.OptionRouter, resp.Options)),
+		"netmask":           fmt.Sprintf("%v", dhcpv4.GetIP(dhcpv4.OptionSubnetMask, resp.Options)),
 	}).Info("DHCPv4 assignment")
 
 	// STEP 2: Send boot config


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

Add 'netmask'/'cidr' keys to set the network mask (DHCP option 1) for DHCPv4 requests. If omitted and 'subnet' is used as a matching key, the network mask will be set to the mask of the first network IP in the subnet list. This overrides the subnet mask set by CoreDHCP's 'netmask' plugin, if set.

Also:

- Move **hostnames.md** to **rules.md** within **examples/coredhcp/** to match generic rules
- Fix router IP validation
- Add missing error comments for rule package
- Add missing unit tests
- Improve `check-reuse` Make target to list noncompliant files

Fixes #58

### Type of Change

- [x] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [x] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
