### PR TITLE
feat(coredhcp): add `ignore` action rule key to ignore matching hosts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,4 +32,4 @@ formatters:
       local-prefixes:
         - github.com/openchami/coresmd/
   exclusions:
-    generated: lax 
+    generated: lax

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN set -ex \
 
 
 # Both coredns and coredhcp are built and added to the same container.
-# By default, coredhcp is started and coredns is not.  To start coredns, override the CMD in the 
+# By default, coredhcp is started and coredns is not.  To start coredns, override the CMD in the
 # container runtime configuration and provide a volume with the appropriate configuration file.
 COPY coredhcp /coredhcp
 COPY coredns /coredns

--- a/examples/coredhcp/coredhcp.yaml
+++ b/examples/coredhcp/coredhcp.yaml
@@ -138,9 +138,21 @@ server4:
     #
     # rule (OPTIONAL, string, repeatable)
     #   Adds a rule. Rules are evaluated in order. A matching rule may set the
-    #   hostname (`hostname:...`) and/or DHCPv4 routers (`routers:...`). Match
-    #   keys are optional (type/subnet/id). If no rule sets a hostname, CoreSMD
-    #   falls back to the built-in default hostname pattern "unknown-{04d}".
+    #   hostname (`hostname:...`) and/or DHCPv4 routers (`routers:...`), or
+    #   drop the request (`ignore:true`). Match keys are optional (type/subnet/id).
+    #   If no rule sets a hostname, CoreSMD falls back to the built-in default
+    #   hostname pattern "unknown-{04d}".
+    #
+    #   Action keys:
+    #   - hostname:PATTERN - Set hostname (supports {04d}, {id} placeholders)
+    #   - routers:IP[|IP...] - Set DHCPv4 router option
+    #   - netmask:MASK or cidr:BITS - Set DHCPv4 subnet mask
+    #   - ignore:{true|false} - Drop DHCP request without responding (takes precedence)
+    #   - continue:{true|false} - Continue evaluating subsequent rules after match
+    #   - domain:DOMAIN - Override global domain for this rule
+    #   - domain_append:MODE - Control domain suffixing behavior
+    #   - log:{info|debug|none} - Per-rule logging override
+    #   - name:STRING - Rule identifier for logs
     #
     #   See examples/coredhcp/rules.md for details and advanced examples.
     #
@@ -189,6 +201,9 @@ server4:
         rule=type:Node,hostname:nid{04d}
         rule=type:NodeBMC,hostname:bmc{04d}
         rule=type:HSNSwitch,hostname:{id}
+        /* OPTIONAL: Drop DHCP requests for specific components/subnets */
+        /* rule=type:RouterBMC,ignore:true,log:info */
+        /* rule=subnet:172.16.99.0/24,ignore:true */
         /* OPTIONAL: override built-in fallback (default is unknown-{04d}) */
         rule=hostname:unknown-{04d}
 

--- a/examples/coredhcp/rules.md
+++ b/examples/coredhcp/rules.md
@@ -38,6 +38,7 @@ match filters.
       - [`domain:DOMAIN`](#domaindomain-1)
       - [`domain_append:MODE`](#domain_appendmode)
       - [`continue:{true|false}`](#continuetruefalse)
+      - [`ignore:{true|false}`](#ignoretruefalse)
       - [`name:STRING`](#namestring)
       - [`log:{info|debug|none}`](#loginfodebugnone)
   - [Rule Ordering](#rule-ordering)
@@ -232,7 +233,7 @@ Mutually exclusive with `id`.
 ### Action Keys
 
 Rules may apply one or more actions when matched. At least one action must be
-specified (`hostname`, `routers`, `netmask`, or `cidr`). If no match keys are
+specified (`hostname`, `routers`, `netmask`, `cidr`, or `ignore`). If no match keys are
 specified, the action(s) will apply to all incoming DHCP requests.
 
 #### `hostname:PATTERN`
@@ -332,6 +333,52 @@ If `true`, evaluation continues after a match.
 If `false`, evaluation ceases after a match and the hostname is final.
 
 **Default:** `false`
+
+#### `ignore:{true|false}`
+
+When set to `true`, causes CoreSMD to drop the DHCP request without sending a
+response. The client will not receive any DHCP response from the CoreSMD plugin.
+
+This is useful for explicitly filtering out components that should not receive
+DHCP leases from CoreSMD, such as:
+
+- Specific component types that should be handled by other DHCP plugins
+- Test/maintenance subnets that should be ignored
+- Individual components that are being decommissioned
+
+**Behavior:**
+
+- If `ignore:true` is present in a matching rule, it takes precedence over all
+  other actions (`hostname`, `routers`, `netmask`, `cidr`)
+- The DHCP request is dropped immediately upon matching the rule, before any
+  DHCP options are set
+- The request does NOT continue to subsequent CoreDHCP plugins (bootloop, file, etc.)
+- Logging respects the rule's `log` setting (info/debug/none)
+
+**Default:** `false` (when not specified or explicitly set to `false`, the rule
+behaves normally and processes other actions)
+
+**Examples:**
+
+```yaml
+# Drop all RouterBMC DHCP requests
+rule=type:RouterBMC,ignore:true,log:info
+
+# Drop requests from specific subnet
+rule=subnet:172.16.99.0/24,ignore:true
+
+# Drop specific component by xname
+rule=id:x3000c0s0b999,ignore:true
+
+# Combine with continue for complex filtering
+rule=type:Node,subnet:10.0.0.0/8,ignore:true
+rule=type:Node,hostname:compute-{04d}
+
+# Explicit false (no-op, since false is default)
+rule=type:Node,hostname:compute-{04d},ignore:false
+```
+
+**See also:** [`continue`](#continuetruefalse) action key for controlling rule evaluation flow.
 
 #### `name:STRING`
 

--- a/examples/coredns/advanced/Corefile
+++ b/examples/coredns/advanced/Corefile
@@ -5,7 +5,7 @@
 
 # Advanced CoreSMD CoreDNS Configuration
 # This configuration provides DNS resolution with custom zones and TLS support
-# 
+#
 # This example demonstrates advanced features including:
 # - TLS certificate validation for secure SMD communication
 # - Multiple zone configurations for different domains
@@ -18,31 +18,31 @@
     coresmd {
         # URL of the SMD server that provides component information
         smd_url https://smd.cluster.local
-        
+
         # CA certificate for validating SMD server TLS certificate
         # Required for secure communication in production environments
         ca_cert /etc/ssl/certs/smd-ca.crt
-        
+
         # Extended cache duration for production (60 seconds)
         # Longer cache reduces SMD server load but may delay updates
         cache_duration 60s
-        
+
         # Primary zone configuration for cluster.local domain
         zone cluster.local {
             # Pattern for compute node hostnames: nid0001, nid0002, etc.
             nodes nid{04d}
         }
-        
+
         # Secondary zone configuration for management network
         zone mgmt.local {
             # Pattern for management node hostnames: mgmt0001, mgmt0002, etc.
             nodes mgmt{04d}
         }
     }
-    
+
     # Prometheus metrics endpoint for monitoring and alerting
     prometheus 0.0.0.0:9153
-    
+
     # Forward all other queries to Google's DNS servers
     forward . 8.8.8.8
-} 
+}

--- a/examples/coredns/basic/Corefile
+++ b/examples/coredns/basic/Corefile
@@ -5,7 +5,7 @@
 
 # Basic CoreSMD CoreDNS Configuration
 # This configuration provides DNS resolution for OpenCHAMI cluster components
-# 
+#
 # The coresmd plugin integrates with the OpenCHAMI SMD (State Management Database)
 # to provide dynamic DNS resolution for compute nodes and BMCs (Baseboard Management Controllers)
 # based on their hardware addresses and component information.
@@ -16,20 +16,20 @@
     coresmd {
         # URL of the SMD server that provides component information
         smd_url https://demo.openchami.cluster:8443
-        
+
         # How long to cache SMD data before refreshing (30 seconds)
         cache_duration 30s
-        
+
         # Zone configuration for openchami.cluster domain
         zone openchami.cluster {
             # Pattern for node hostnames: nid0001, nid0002, etc.
             nodes nid{04d}
         }
     }
-    
+
     # Prometheus metrics endpoint for monitoring
     prometheus 0.0.0.0:9153
-    
+
     # Forward all other queries to Google's DNS servers
     forward . 8.8.8.8
-} 
+}

--- a/examples/coredns/kubernetes/coredns-configmap.yaml
+++ b/examples/coredns/kubernetes/coredns-configmap.yaml
@@ -13,14 +13,14 @@ data:
     # CoreSMD CoreDNS Configuration for Kubernetes
     # This configuration provides DNS resolution for OpenCHAMI cluster components
     # within a Kubernetes environment
-    # 
+    #
     # The coresmd plugin integrates with the OpenCHAMI SMD (State Management Database)
     # to provide dynamic DNS resolution for compute nodes and BMCs based on their
     # hardware addresses and component information stored in SMD.
-    # 
+    #
     # In Kubernetes, this ConfigMap is mounted into the CoreDNS container and
     # provides the DNS configuration for the cluster's internal DNS service.
-    
+
     # Main DNS server block - handles all queries
     . {
         # CoreSMD plugin configuration
@@ -28,26 +28,26 @@ data:
             # URL of the SMD server that provides component information
             # In Kubernetes, this should be accessible from within the cluster
             smd_url https://smd.cluster.local
-            
+
             # CA certificate for validating SMD server TLS certificate
             # This certificate should be mounted as a volume in the CoreDNS deployment
             ca_cert /etc/ssl/certs/smd-ca.crt
-            
+
             # Cache duration for SMD data (60 seconds)
             # Longer cache reduces SMD server load in production environments
             cache_duration 60s
-            
+
             # Zone configuration for cluster.local domain
             zone cluster.local {
                 # Pattern for compute node hostnames: nid0001, nid0002, etc.
                 nodes nid{04d}
             }
         }
-        
+
         # Prometheus metrics endpoint for monitoring
         # Accessible at :9153/metrics for monitoring and alerting
         prometheus 0.0.0.0:9153
-        
+
         # Forward all other queries to upstream DNS servers
         forward . 8.8.8.8
-    } 
+    }

--- a/examples/coredns/kubernetes/coredns-deployment.yaml
+++ b/examples/coredns/kubernetes/coredns-deployment.yaml
@@ -88,4 +88,4 @@ spec:
   - name: metrics
     port: 9153
     protocol: TCP
-  type: ClusterIP 
+  type: ClusterIP

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/pin/tftp/v3 v3.1.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.3
-	github.com/spf13/pflag v1.0.10
 )
 
 require (
@@ -43,7 +42,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -73,6 +71,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.20.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
-github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -84,8 +82,6 @@ github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167 h1:MEufgJohwIjFi
 github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
-github.com/josharian/native v1.1.0/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -110,10 +106,6 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mdlayher/packet v1.1.2 h1:3Up1NG6LZrsgDVn6X4L9Ge/iyRyxFEFD9o6Pr3Q1nQY=
-github.com/mdlayher/packet v1.1.2/go.mod h1:GEu1+n9sG5VtiRE4SydOmX5GTwyyYlteZiFU+x0kew4=
-github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
-github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
@@ -232,7 +224,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
 golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
@@ -265,7 +256,6 @@ golang.org/x/text v0.34.0/go.mod h1:homfLqTYRFyVYemLBFl5GgL/DWEiH5wcsQ5gSh1yziA=
 golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -32,6 +32,7 @@ var AllowedKeys = []string{
 	"hostname",
 	"id",
 	"id_set",
+	"ignore",
 	"log",
 	"name",
 	"netmask",
@@ -184,6 +185,7 @@ type Action struct {
 	Netmask      net.IPMask // rule-specific network mask for IPv4
 	Routers      []net.IP   // router IPs for selected component(s)
 	Continue     bool       // whether to continue parsing subsequent rules if this matches
+	Ignore       bool       // if true, drop DHCP request without responding (takes precedence over all other actions)
 }
 
 func (a Action) String() string {
@@ -203,6 +205,7 @@ func (a Action) String() string {
 		actionStr += fmt.Sprintf(",domain_append:%s", da)
 	}
 	actionStr += fmt.Sprintf(",continue:%v", a.Continue)
+	actionStr += fmt.Sprintf(",ignore:%v", a.Ignore)
 
 	// Canonicalize netmask for IPv4 to CIDR notation
 	if ones, _ := a.Netmask.Size(); ones > 0 {
@@ -357,6 +360,15 @@ func ParseRule(rule string) (Rule, error) {
 		}
 	}
 
+	// ignore (optional, defaults to false)
+	if ignore, ok := comps["ignore"]; ok && ignore != "" {
+		if b, err := parse.ParseBoolLoose(ignore); err != nil {
+			return Rule{}, NewErrInvalidValue("ignore", ignore, "boolean")
+		} else {
+			a.Ignore = b
+		}
+	}
+
 	// domain_append (optional)
 	//
 	// Valid values:
@@ -432,10 +444,13 @@ func ParseRule(rule string) (Rule, error) {
 	// Netmask can be set explicitly via netmask/cidr or implicitly from subnet.
 	// In this way, subnet can be considered an "action" and is the only match
 	// key to be considered such.
+	//
+	// The ignore action is also valid as a standalone action.
 	if strings.TrimSpace(a.Hostname) == "" &&
-		len(a.Routers) == 0 {
+		len(a.Routers) == 0 &&
+		!a.Ignore {
 		if ones, size := a.Netmask.Size(); ones == 0 || size == 0 {
-			return Rule{}, NewErrRequiredKeys("hostname", "routers", "netmask")
+			return Rule{}, NewErrRequiredKeys("hostname", "routers", "netmask", "ignore")
 		}
 	}
 
@@ -554,7 +569,10 @@ func normalizeDomainAppend(raw string) (string, error) {
 //
 // The global settings globalDomain and ruleLog are also passed for effecting
 // rule evaluation behavior.
-func Evaluate4(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog string, resp *dhcpv4.DHCPv4, rules []Rule) {
+//
+// Returns true if a DHCP response should be sent, false if the request should
+// be dropped (due to an ignore action).
+func Evaluate4(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog string, resp *dhcpv4.DHCPv4, rules []Rule) bool {
 	// Init default logger if unset
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.New())
@@ -628,6 +646,29 @@ func Evaluate4(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog s
 			//
 			// PERFORM ACTIONS HERE
 			//
+
+			// Check if request should be ignored (takes precedence over all other actions)
+			if rule.Action.Ignore {
+				// Log according to rule's log level
+				var loggingEnabled bool
+				switch rule.Log {
+				case "info", "debug":
+					loggingEnabled = true
+				case "", "none":
+					// Inherit from global or suppress
+					if ruleLog == "info" || ruleLog == "debug" {
+						loggingEnabled = true
+					}
+				}
+				if loggingEnabled {
+					logger.WithFields(logrus.Fields{
+						"comp_id":   ii.CompID,
+						"comp_type": ii.Type,
+						"mac":       ii.MAC,
+					}).Infof("rule[%d] (%s) matched with ignore=true, dropping DHCP request", idx, rule.Name)
+				}
+				return false // Do not send DHCP response to client
+			}
 
 			// Set hostname
 			if hn := strings.TrimSpace(rule.Action.Hostname); hn != "" {
@@ -675,6 +716,8 @@ func Evaluate4(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog s
 	if len(bytes.TrimSpace(resp.Options.Get(dhcpv4.OptionHostName))) == 0 {
 		resp.Options.Update(dhcpv4.OptHostName(lookupHostname(DefaultPattern, globalDomain, ii, Rule{})))
 	}
+
+	return true // Send DHCP response to client
 }
 
 // Evaluate6 takes interface information from a DHCPv6 request and a list of
@@ -686,7 +729,10 @@ func Evaluate4(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog s
 //
 // The global settings globalDomain and ruleLog are also passed for effecting
 // rule evaluation behavior.
-func Evaluate6(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog string, resp *dhcpv6.Message, rules []Rule) {
+//
+// Returns true if a DHCP response should be sent, false if the request should
+// be dropped (due to an ignore action).
+func Evaluate6(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog string, resp *dhcpv6.Message, rules []Rule) bool {
 	// Init default logger if unset
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.New())
@@ -761,6 +807,29 @@ func Evaluate6(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog s
 			// PERFORM ACTIONS HERE
 			//
 
+			// Check if request should be ignored (takes precedence over all other actions)
+			if rule.Action.Ignore {
+				// Log according to rule's log level
+				var loggingEnabled bool
+				switch rule.Log {
+				case "info", "debug":
+					loggingEnabled = true
+				case "", "none":
+					// Inherit from global or suppress
+					if ruleLog == "info" || ruleLog == "debug" {
+						loggingEnabled = true
+					}
+				}
+				if loggingEnabled {
+					logger.WithFields(logrus.Fields{
+						"comp_id":   ii.CompID,
+						"comp_type": ii.Type,
+						"mac":       ii.MAC,
+					}).Infof("rule[%d] (%s) matched with ignore=true, dropping DHCPv6 request", idx, rule.Name)
+				}
+				return false // Do not send a DHCP response to client
+			}
+
 			// Set hostname
 			if hn := strings.TrimSpace(rule.Action.Hostname); hn != "" {
 				hname := lookupHostname(hn, globalDomain, ii, rule)
@@ -788,6 +857,8 @@ func Evaluate6(logger *logrus.Entry, ii iface.IfaceInfo, globalDomain, ruleLog s
 		labels := &rfc1035label.Labels{Labels: strings.Split(hname, ".")}
 		resp.UpdateOption(&dhcpv6.OptFQDN{Flags: 0, DomainName: labels})
 	}
+
+	return true // Send DHCP response to client
 }
 
 // createRuleCompDict parses a rule string and creates a map of each rule

--- a/internal/rule/rule_test.go
+++ b/internal/rule/rule_test.go
@@ -253,3 +253,191 @@ func TestEvaluate6_HostnameAndDefault(t *testing.T) {
 		t.Fatalf("expected=%q got=%q", "unknown-0007.cluster.local", got2)
 	}
 }
+
+// TestParseRule_Ignore tests parsing of the ignore action
+func TestParseRule_Ignore(t *testing.T) {
+	tests := []struct {
+		name       string
+		rule       string
+		wantIgnore bool
+		wantErr    bool
+	}{
+		{"ignore_true", "ignore:true", true, false},
+		{"ignore_false", "ignore:false,hostname:test", false, false},
+		{"ignore_yes", "ignore:yes", true, false},
+		{"ignore_no", "ignore:no,hostname:test", false, false},
+		{"ignore_1", "ignore:1", true, false},
+		{"ignore_0", "ignore:0,hostname:test", false, false},
+		{"ignore_invalid", "ignore:maybe,hostname:test", false, true},
+		{"ignore_with_subnet", "subnet:172.16.0.0/24,ignore:true", true, false},
+		{"ignore_with_type", "type:RouterBMC,ignore:true", true, false},
+		{"ignore_with_hostname", "type:Node,hostname:compute-{04d},ignore:true", true, false},
+		{"ignore_alone_valid", "ignore:true", true, false},
+		{"ignore_false_no_other_action", "ignore:false", false, true}, // Should fail validation
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := ParseRule(tt.rule)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseRule(%q): err=%v wantErr=%v", tt.rule, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if r.Action.Ignore != tt.wantIgnore {
+				t.Fatalf("ParseRule(%q): got Ignore=%v want=%v", tt.rule, r.Action.Ignore, tt.wantIgnore)
+			}
+		})
+	}
+}
+
+// TestEvaluate4_Ignore tests that DHCPv4 requests are dropped when ignore=true
+func TestEvaluate4_Ignore(t *testing.T) {
+	// Test component info
+	ii := iface.IfaceInfo{
+		CompID:  "x3000c0s0b0n0",
+		CompNID: 5,
+		Type:    "Node",
+		MAC:     "de:ad:be:ef:00:01",
+		IPList:  []net.IP{net.ParseIP("172.16.0.10")},
+	}
+
+	// Create a DHCPv4 response
+	resp, err := dhcpv4.NewReplyFromRequest(&dhcpv4.DHCPv4{})
+	if err != nil {
+		t.Fatalf("failed to create DHCPv4 response: %v", err)
+	}
+
+	t.Run("ignore_true_drops_request", func(t *testing.T) {
+		rules := []Rule{{
+			Name:   "drop_all",
+			Match:  Match{Types: map[string]bool{"Node": true}},
+			Action: Action{Ignore: true},
+		}}
+
+		shouldRespond := Evaluate4(nil, ii, "test.local", "info", resp, rules)
+		if shouldRespond {
+			t.Fatalf("expected shouldRespond=false got=true")
+		}
+
+		// Verify no hostname was set (request dropped before actions)
+		if len(resp.Options.Get(dhcpv4.OptionHostName)) > 0 {
+			t.Fatalf("expected no hostname to be set when ignored")
+		}
+	})
+
+	t.Run("ignore_false_allows_request", func(t *testing.T) {
+		resp2, _ := dhcpv4.NewReplyFromRequest(&dhcpv4.DHCPv4{})
+		rules := []Rule{{
+			Name:   "allow_with_hostname",
+			Match:  Match{Types: map[string]bool{"Node": true}},
+			Action: Action{Ignore: false, Hostname: "test-{04d}"},
+		}}
+
+		shouldRespond := Evaluate4(nil, ii, "test.local", "info", resp2, rules)
+		if !shouldRespond {
+			t.Fatalf("expected shouldRespond=true got=false")
+		}
+
+		// Verify hostname was set
+		hostname := string(resp2.Options.Get(dhcpv4.OptionHostName))
+		if !strings.HasPrefix(hostname, "test-") {
+			t.Fatalf("expected hostname to be set, got=%q", hostname)
+		}
+	})
+
+	t.Run("ignore_takes_precedence", func(t *testing.T) {
+		resp3, _ := dhcpv4.NewReplyFromRequest(&dhcpv4.DHCPv4{})
+		rules := []Rule{{
+			Name:   "ignore_with_other_actions",
+			Match:  Match{Types: map[string]bool{"Node": true}},
+			Action: Action{Ignore: true, Hostname: "should-not-set"},
+		}}
+
+		shouldRespond := Evaluate4(nil, ii, "test.local", "info", resp3, rules)
+		if shouldRespond {
+			t.Fatalf("expected shouldRespond=false (ignore takes precedence)")
+		}
+
+		// Verify hostname was NOT set
+		if len(resp3.Options.Get(dhcpv4.OptionHostName)) > 0 {
+			t.Fatalf("expected no hostname when ignored, got=%q", resp3.Options.Get(dhcpv4.OptionHostName))
+		}
+	})
+
+	t.Run("no_match_continues_to_default", func(t *testing.T) {
+		resp4, _ := dhcpv4.NewReplyFromRequest(&dhcpv4.DHCPv4{})
+		rules := []Rule{{
+			Name:   "wont_match",
+			Match:  Match{Types: map[string]bool{"RouterBMC": true}},
+			Action: Action{Ignore: true},
+		}}
+
+		shouldRespond := Evaluate4(nil, ii, "test.local", "info", resp4, rules)
+		if !shouldRespond {
+			t.Fatalf("expected shouldRespond=true when no rule matches")
+		}
+
+		// Verify default hostname was set
+		hostname := string(resp4.Options.Get(dhcpv4.OptionHostName))
+		if !strings.HasPrefix(hostname, "unknown-") {
+			t.Fatalf("expected default hostname pattern, got=%q", hostname)
+		}
+	})
+}
+
+// TestEvaluate6_Ignore tests that DHCPv6 requests are dropped when ignore=true
+func TestEvaluate6_Ignore(t *testing.T) {
+	// Test component info with IPv6
+	ii := iface.IfaceInfo{
+		CompID:  "x3000c0s0b0n0",
+		CompNID: 5,
+		Type:    "Node",
+		MAC:     "de:ad:be:ef:00:01",
+		IPList:  []net.IP{net.ParseIP("2001:db8::1")},
+	}
+
+	t.Run("ignore_true_drops_request", func(t *testing.T) {
+		resp, err := dhcpv6.NewMessage()
+		if err != nil {
+			t.Fatalf("failed to create DHCPv6 response: %v", err)
+		}
+
+		rules := []Rule{{
+			Name:   "drop_all_v6",
+			Match:  Match{Types: map[string]bool{"Node": true}},
+			Action: Action{Ignore: true},
+		}}
+
+		shouldRespond := Evaluate6(nil, ii, "test.local", "info", resp, rules)
+		if shouldRespond {
+			t.Fatalf("expected shouldRespond=false got=true")
+		}
+
+		// Verify no FQDN was set
+		if opt := resp.GetOneOption(dhcpv6.OptionFQDN); opt != nil {
+			t.Fatalf("expected no FQDN when ignored, got=%v", opt)
+		}
+	})
+
+	t.Run("ignore_false_allows_request", func(t *testing.T) {
+		resp, _ := dhcpv6.NewMessage()
+		rules := []Rule{{
+			Name:   "allow_with_hostname_v6",
+			Match:  Match{Types: map[string]bool{"Node": true}},
+			Action: Action{Ignore: false, Hostname: "test-{04d}"},
+		}}
+
+		shouldRespond := Evaluate6(nil, ii, "test.local", "info", resp, rules)
+		if !shouldRespond {
+			t.Fatalf("expected shouldRespond=true got=false")
+		}
+
+		// Verify FQDN was set
+		opt := resp.GetOneOption(dhcpv6.OptionFQDN)
+		if opt == nil {
+			t.Fatalf("expected FQDN option to be set")
+		}
+	})
+}

--- a/internal/smdclient/smdclient.go
+++ b/internal/smdclient/smdclient.go
@@ -9,7 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -103,7 +103,7 @@ func (sc *SmdClient) APIGet(path string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/plugin/coredhcp/coresmd/main.go
+++ b/plugin/coredhcp/coresmd/main.go
@@ -470,7 +470,12 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 	}
 
 	// Apply rules
-	rule.Evaluate4(log, ifaceInfo, globalConfig.domain, globalConfig.ruleLog, resp, globalConfig.rules)
+	shouldRespond := rule.Evaluate4(log, ifaceInfo, globalConfig.domain, globalConfig.ruleLog, resp, globalConfig.rules)
+	if !shouldRespond {
+		// Drop request and return nil to prevent response
+		log.Debugf("DHCP request dropped due to ignore rule for %s", ifaceInfo.MAC)
+		return nil, true
+	}
 
 	// Set root path to this server's IP
 	resp.Options.Update(dhcpv4.OptRootPath(resp.ServerIPAddr.String()))
@@ -552,7 +557,12 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 	}
 
 	// Apply rules
-	rule.Evaluate6(log, ifaceInfo, globalConfig.domain, globalConfig.ruleLog, msg, globalConfig.rules)
+	shouldRespond := rule.Evaluate6(log, ifaceInfo, globalConfig.domain, globalConfig.ruleLog, msg, globalConfig.rules)
+	if !shouldRespond {
+		// Drop request and return nil to prevent response
+		log.Debugf("DHCPv6 request dropped due to ignore rule for %s", ifaceInfo.MAC)
+		return nil, true
+	}
 
 	// Add IANA (Identity Association for Non-temporary Addresses) with the IPv6 address
 	reqMsg, ok := req.(*dhcpv6.Message)


### PR DESCRIPTION
## Pull Request Template

Thank you for your contribution! Please ensure the following before submitting:

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Description

Add an `ignore` action key to the rule specification for CoreDHCP to toggle ignoring DHCP requests from hosts matching the rule. The DHCP requests for such hosts will be dropped and rule evaluation halted for them. This is useful for temporarily "disabling" nodes tracked in SMD in environments such as transitioning to/from OpenCHAMI or decommissioning.

Fixes #62 

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
