### PR TITLE
feat!: replace ipxe_base_uri with ipxe_uri for full customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ SPDX-License-Identifier: MIT
     - [CoreDNS](#coredns-1)
   - [Running](#running)
     - [Configuration](#configuration-1)
-    - [Preparation: SMD and BSS](#preparation-smd-and-bss)
+    - [Preparation: SMD and boot-service](#preparation-smd-and-boot-service)
     - [Preparation: TFTP](#preparation-tftp)
     - [Running](#running-1)
       - [CoreDHCP](#coredhcp-2)
@@ -276,9 +276,9 @@ CoreDHCP requires a config file to run. See [**examples/coredhcp/coredhcp.yaml**
 
 CoreDNS similarly has a **Corefile** to use. See [**examples/coredns/**](examples/coredns/) for examples of Corefiles.
 
-### Preparation: SMD and BSS
+### Preparation: SMD and boot-service
 
-Before running CoreDHCP/CoreDNS, ensure the [OpenCHAMI](https://openchami.org) services (notably **BSS** and **SMD**) are configured and running. Their URLs should match what you configure in the CoreDHCP config file.
+Before running CoreDHCP/CoreDNS, ensure the [OpenCHAMI](https://openchami.org) services (notably **SMD** and a boot script service such as **boot-service** or legacy **BSS**) are configured and running. Their URLs should match what you configure in the CoreDHCP config file.
 
 ### Preparation: TFTP
 
@@ -401,4 +401,3 @@ Once all prerequisites are set, you can run CoreDHCP or CoreDNS.
 - [SMD GitHub](https://github.com/OpenCHAMI/smd)
 - [GoReleaser Documentation](https://goreleaser.com/install/)
 - [Magellan (OpenCHAMI)](https://github.com/OpenCHAMI/magellan)
-

--- a/examples/coredhcp/README.md
+++ b/examples/coredhcp/README.md
@@ -32,7 +32,7 @@ To migrate the above configuration to the new format, it would become:
 
 ```yaml
 plugins:
-  - coresmd: svc_base_uri=https://foobar.openchami.cluster ipxe_base_uri=http://172.16.0.253:8081 ca_cert=/root_ca/root_ca.crt cache_valid=30s lease_time=1h single_port=false
+  - coresmd: svc_base_uri=https://foobar.openchami.cluster ipxe_uri=http://172.16.0.253:8081/bootscript ca_cert=/root_ca/root_ca.crt cache_valid=30s lease_time=1h single_port=false
 ```
 
 So as to not have an endless text line, a YAML multi-line string can also be used to separate the arguments:
@@ -41,7 +41,7 @@ So as to not have an endless text line, a YAML multi-line string can also be use
 plugins:
   - coresmd: |
       svc_base_uri=https://foobar.openchami.cluster
-      ipxe_base_uri=http://172.16.0.253:8081
+      ipxe_uri=http://172.16.0.253:8081/bootscript
       ca_cert=/root_ca/root_ca.crt
       cache_valid=30s
       lease_time=1h single_port=false
@@ -54,8 +54,8 @@ plugins:
   - coresmd: |
       /* SMD base URI */
       svc_base_uri=https://foobar.openchami.cluster
-      /* BSS boot script base URI */
-      ipxe_base_uri=http://172.16.0.253:8081
+      /* Boot script URI */
+      ipxe_uri=http://172.16.0.253:8081/bootscript
       /* CA trust bundle */
       ca_cert=/root_ca/root_ca.crt
       /* SMD cache validity duration */
@@ -94,7 +94,7 @@ plugins:
   - dns: fd00:100::254
   - coresmd: |
       svc_base_uri=https://smd.openchami.cluster
-      ipxe_base_uri=http://[fd00:100::254]:8081
+      ipxe_uri=http://[fd00:100::254]:8081/bootscript
       ca_cert=/root_ca/root_ca.crt
       cache_valid=30s
       lease_time=1h

--- a/examples/coredhcp/coredhcp-minimal.yaml
+++ b/examples/coredhcp/coredhcp-minimal.yaml
@@ -33,7 +33,7 @@ server4:
     # CoreSMD plugin for dynamic IP assignment
     - coresmd: |
         svc_base_uri=http://smd.cluster.local
-        ipxe_base_uri=http://192.168.1.1:8081
+        ipxe_uri=http://192.168.1.1:8081/bootscript
         cache_valid=30s
         lease_time=24h
         /* Rules (see examples/coredhcp/hostnames.md) */
@@ -61,7 +61,7 @@ server6:
     # CoreSMD plugin for dynamic IPv6 assignment
     - coresmd: |
         svc_base_uri=http://smd.cluster.local
-        ipxe_base_uri=http://[fd00::1]:8081
+        ipxe_uri=http://[fd00::1]:8081/bootscript
         cache_valid=30s
         lease_time=24h
         /* Rules (see examples/coredhcp/hostnames.md) */

--- a/examples/coredhcp/coredhcp.yaml
+++ b/examples/coredhcp/coredhcp.yaml
@@ -104,11 +104,28 @@ server4:
     #   The base URI used to communicate with SMD. The SMD API
     #   paths are appended to this.
     #
-    # ipxe_base_uri (REQUIRED, string)
-    #   The base URI used to retrieve boot scripts. This is usually a base HTTP
-    #   URL to BSS, since the iPXE bootloader served by CoreSMD doesn't include
-    #   an OpenCHAMI CA certificate by default to do proper TLS. It may also be
-    #   an IP address if name servers are nod configured.
+    # ipxe_uri (REQUIRED, string)
+    #   The URI used to retrieve boot scripts. This is usually a full HTTP URI
+    #   to boot-service's boot script endpoint. Since the iPXE bootloader
+    #   served by CoreSMD doesn't include an OpenCHAMI CA certificate by
+    #   default to do proper TLS, http:// is supported alongside https://. It
+    #   may also be an IP address if name servers are not configured.
+    #
+    #   If using the legacy BSS API instead of the boot-service API, the URI
+    #   will likely look different than when using the boot-service URI. For
+    #   example, instead of using the following boot-service boot script URI:
+    #
+    #     ipxe_uri=http://<ip>:8081/bootscript
+    #
+    #   It would be the following for BSS:
+    #
+    #     ipxe_uri=http://<ip>:8081/boot/v1/bootscript
+    #
+    #   If using an API gateway, ensure to use whatever prefix is configured.
+    #   For example, if the API gateway routes /boot-service/* requests to
+    #   boot-service, use:
+    #
+    #     ipxe_uri=http://<ip>:8081/boot-service/bootscript
     #
     # ca_cert (OPTIONAL, string)
     #   The path to a certificate authority certificate used for TLS
@@ -180,8 +197,8 @@ server4:
     - coresmd: |
         /* SMD base URI */
         svc_base_uri=https://foobar.openchami.cluster
-        /* BSS base URI for obtaining boot scripts */
-        ipxe_base_uri=http://172.16.0.253:8081
+        /* Boot script URI */
+        ipxe_uri=http://172.16.0.253:8081/bootscript
         /* OPTIONAL: path to CA trust certificate bundle */
         ca_cert=/root_ca/root_ca.crt
         /* OPTIONAL: duration that component/interface cache is valid (default 30s) */
@@ -217,7 +234,7 @@ server4:
     #
     # - coresmd: |
     #     svc_base_uri=https://foobar.openchami.cluster
-    #     ipxe_base_uri=http://172.16.0.253:8081
+    #     ipxe_uri=http://172.16.0.253:8081/bootscript
     #     ca_cert=/root_ca/root_ca.crt
     #     cache_valid=30s
     #     lease_time=1h
@@ -358,17 +375,17 @@ server6:
     # - FQDN options (via domain= configuration) work with DHCPv6
     # - Boot file URLs should use IPv6 addresses in bracket notation:
     #   tftp://[fd00:100::254]:69/ipxe.efi
-    # - The ipxe_base_uri should include IPv6 addresses in bracket notation if
-    #   using IP addresses directly: http://[fd00:100::254]:8081
+    # - The ipxe_uri should include IPv6 addresses in bracket notation if
+    #   using IP addresses directly: http://[fd00:100::254]:8081/bootscript
     #
     # All configuration keys from DHCPv4 apply:
-    # - svc_base_uri, ipxe_base_uri, ca_cert
+    # - svc_base_uri, ipxe_uri, ca_cert
     # - cache_valid, lease_time
     # - single_port, tftp_dir, tftp_port
     # - domain, rule_log, rule
     - coresmd: |
         svc_base_uri=https://foobar.openchami.cluster
-        ipxe_base_uri=http://[fd00:100::254]:8081
+        ipxe_uri=http://[fd00:100::254]:8081/bootscript
         ca_cert=/root_ca/root_ca.crt
         cache_valid=30s
         lease_time=1h

--- a/examples/coredhcp/rules.md
+++ b/examples/coredhcp/rules.md
@@ -63,7 +63,7 @@ In a CoreDHCP configuration:
 ```yaml
 - coresmd: |
     svc_base_uri=https://smd.cluster.local
-    ipxe_base_uri=http://192.168.1.1
+    ipxe_uri=http://192.168.1.1:8081/bootscript
     cache_valid=30s
     lease_time=24h
     domain=cluster.local
@@ -420,7 +420,7 @@ generic naming followed by narrow overrides.
 ```yaml
 - coresmd: |
     svc_base_uri=https://smd.cluster.local
-    ipxe_base_uri=http://192.168.1.1
+    ipxe_uri=http://192.168.1.1:8081/bootscript
     rule=type:Node,hostname:nid{04d}
 ```
 

--- a/plugin/coredhcp/coresmd/main.go
+++ b/plugin/coredhcp/coresmd/main.go
@@ -34,7 +34,7 @@ import (
 type Config struct {
 	// Parsed from configuration file
 	svcBaseURI    *url.URL              // svc_base_uri
-	ipxeBaseURI   *url.URL              // ipxe_base_uri
+	ipxeURI       *url.URL              // ipxe_uri
 	caCert        string                // ca_cert
 	cacheValid    *time.Duration        // cache_valid
 	leaseTime     *time.Duration        // lease_time
@@ -48,9 +48,9 @@ type Config struct {
 }
 
 func (c Config) String() string {
-	cfgStr := fmt.Sprintf("svc_base_uri=%s ipxe_base_uri=%s ca_cert=%s cache_valid=%s lease_time=%s single_port=%v tftp_dir=%s tftp_port=%d domain=%s rule_log=%s",
+	cfgStr := fmt.Sprintf("svc_base_uri=%s ipxe_uri=%s ca_cert=%s cache_valid=%s lease_time=%s single_port=%v tftp_dir=%s tftp_port=%d domain=%s rule_log=%s",
 		c.svcBaseURI,
-		c.ipxeBaseURI,
+		c.ipxeURI,
 		c.caCert,
 		c.cacheValid,
 		c.leaseTime,
@@ -247,12 +247,12 @@ func parseConfig(argv ...string) (cfg Config, errs []error) {
 			} else {
 				cfg.svcBaseURI = svcURI
 			}
-		case "ipxe_base_uri":
+		case "ipxe_uri":
 			if ipxeURI, err := url.Parse(opt[1]); err != nil {
 				errs = append(errs, fmt.Errorf("non-comment arg %d: %s: invalid URI '%s' (skipping): %w", idx, opt[0], opt[1], err))
 				continue
 			} else {
-				cfg.ipxeBaseURI = ipxeURI
+				cfg.ipxeURI = ipxeURI
 			}
 		case "ca_cert":
 			// Simply set if nonempty when trimmed. Checking happens later.
@@ -378,8 +378,8 @@ func (c *Config) validate() (warns []string, errs []error) {
 	if c.svcBaseURI == nil {
 		errs = append(errs, fmt.Errorf("svc_base_uri is required"))
 	}
-	if c.ipxeBaseURI == nil {
-		errs = append(errs, fmt.Errorf("ipxe_base_uri is required"))
+	if c.ipxeURI == nil {
+		errs = append(errs, fmt.Errorf("ipxe_uri is required"))
 	}
 	if c.caCert == "" {
 		warns = append(warns, "ca_cert unset, TLS certificates will not be validated")
@@ -428,6 +428,14 @@ func (c *Config) validate() (warns []string, errs []error) {
 		}
 	}
 	return
+}
+
+// bootscriptURI returns a string of the passed URI (presumed to be the iPXE
+// URI) concatenated with a mac= query parameter with the passed MAC address.
+func bootScriptURIForMAC(base *url.URL, mac string) string {
+	scriptURI := *base
+	scriptURI.RawQuery = fmt.Sprintf("mac=%s", mac)
+	return scriptURI.String()
 }
 
 func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
@@ -501,10 +509,8 @@ func Handler4(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
 		// BOOT STAGE 1: Send iPXE bootloader over TFTP
 		resp, _ = ipxe.ServeIPXEBootloader(log, req, resp)
 	} else {
-		// BOOT STAGE 2: Send URL to BSS boot script
-		bssURL := globalConfig.ipxeBaseURI.JoinPath("/boot/v1/bootscript")
-		bssURL.RawQuery = fmt.Sprintf("mac=%s", hwAddr)
-		resp.Options.Update(dhcpv4.OptBootFileName(bssURL.String()))
+		// BOOT STAGE 2: Send URL to boot script
+		resp.Options.Update(dhcpv4.OptBootFileName(bootScriptURIForMAC(globalConfig.ipxeURI, hwAddr)))
 	}
 
 	debug.DebugResponse(log, resp)
@@ -614,10 +620,8 @@ func Handler6(req, resp dhcpv6.DHCPv6) (dhcpv6.DHCPv6, bool) {
 				}
 
 				if isPXE {
-					// BOOT STAGE 2: Send URL to BSS boot script
-					bssURL := globalConfig.ipxeBaseURI.JoinPath("/boot/v1/bootscript")
-					bssURL.RawQuery = fmt.Sprintf("mac=%s", macStr)
-					msg.UpdateOption(dhcpv6.OptBootFileURL(bssURL.String()))
+					// BOOT STAGE 2: Send URL to boot script
+					msg.UpdateOption(dhcpv6.OptBootFileURL(bootScriptURIForMAC(globalConfig.ipxeURI, macStr)))
 				} else {
 					// BOOT STAGE 1: Send iPXE bootloader URL
 					// For DHCPv6, we need to provide the bootfile URL

--- a/plugin/coredhcp/coresmd/main_test.go
+++ b/plugin/coredhcp/coresmd/main_test.go
@@ -23,22 +23,22 @@ func TestConfigString_IncludesKeyFields(t *testing.T) {
 	leaseDur := 5 * time.Minute
 
 	cfg := Config{
-		svcBaseURI:  svc,
-		ipxeBaseURI: ipxe,
-		caCert:      "/etc/ssl/ca.pem",
-		cacheValid:  &cacheDur,
-		leaseTime:   &leaseDur,
-		singlePort:  true,
-		tftpDir:     "/tftp",
-		tftpPort:    1069,
-		domain:      "example.test",
-		ruleLog:     "debug",
+		svcBaseURI: svc,
+		ipxeURI:    ipxe,
+		caCert:     "/etc/ssl/ca.pem",
+		cacheValid: &cacheDur,
+		leaseTime:  &leaseDur,
+		singlePort: true,
+		tftpDir:    "/tftp",
+		tftpPort:   1069,
+		domain:     "example.test",
+		ruleLog:    "debug",
 	}
 
 	s := cfg.String()
 	wantSubstrings := []string{
 		"svc_base_uri=" + svc.String(),
-		"ipxe_base_uri=" + ipxe.String(),
+		"ipxe_uri=" + ipxe.String(),
 		"ca_cert=/etc/ssl/ca.pem",
 		"cache_valid=" + cacheDur.String(),
 		"lease_time=" + leaseDur.String(),
@@ -61,7 +61,7 @@ func TestParseConfig_Rules(t *testing.T) {
 
 	args := []string{
 		"svc_base_uri=https://svc.example.test",
-		"ipxe_base_uri=https://ipxe.example.test",
+		"ipxe_uri=https://ipxe.example.test/bootscript",
 		"ca_cert=/etc/pki/ca.pem",
 		"cache_valid=" + cacheDur.String(),
 		"lease_time=" + leaseDur.String(),
@@ -110,13 +110,73 @@ func TestParseConfig_Rules(t *testing.T) {
 	}
 }
 
+func TestParseConfig_IPXEURI(t *testing.T) {
+	cfg, errs := parseConfig(
+		"svc_base_uri=https://svc.example.test",
+		"ipxe_uri=https://ipxe.example.test/bootscript",
+	)
+	if len(errs) != 0 {
+		t.Fatalf("parseConfig() unexpected errors: %v", errs)
+	}
+	if cfg.ipxeURI == nil {
+		t.Fatal("ipxeURI is nil")
+	}
+	if got, want := cfg.ipxeURI.String(), "https://ipxe.example.test/bootscript"; got != want {
+		t.Fatalf("ipxeURI=%q, want %q", got, want)
+	}
+}
+
+func TestParseConfig_LegacyIPXEBaseURIRejected(t *testing.T) {
+	_, errs := parseConfig(
+		"svc_base_uri=https://svc.example.test",
+		"ipxe_base_uri=https://ipxe.example.test",
+	)
+	if len(errs) == 0 {
+		t.Fatal("parseConfig() expected error for legacy ipxe_base_uri")
+	}
+	if !strings.Contains(errs[0].Error(), "unknown config key 'ipxe_base_uri'") {
+		t.Fatalf("parseConfig() error=%q, want unknown legacy key", errs[0])
+	}
+}
+
+func TestBootScriptURI_UsesConfiguredFullPath(t *testing.T) {
+	tests := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{
+			name: "boot-service",
+			uri:  "http://ipxe.example.test:8081/bootscript",
+			want: "http://ipxe.example.test:8081/bootscript?mac=00:11:22:33:44:55",
+		},
+		{
+			name: "legacy-bss",
+			uri:  "http://ipxe.example.test:8081/boot/v1/bootscript",
+			want: "http://ipxe.example.test:8081/boot/v1/bootscript?mac=00:11:22:33:44:55",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipxeURI, _ := url.Parse(tt.uri)
+			if got := bootScriptURIForMAC(ipxeURI, "00:11:22:33:44:55"); got != tt.want {
+				t.Fatalf("bootScriptURIForMAC()=%q, want %q", got, tt.want)
+			}
+			if got := ipxeURI.String(); got != tt.uri {
+				t.Fatalf("bootScriptURIForMAC() mutated input URI to %q, want %q", got, tt.uri)
+			}
+		})
+	}
+}
+
 func TestConfigValidate_RuleLogInheritance(t *testing.T) {
 	svc, _ := url.Parse("https://svc.example.test")
 	ipxe, _ := url.Parse("https://ipxe.example.test")
 
 	// Create a config with a rule that omits Log; validate should set the
 	// effective per-rule log to the global rule_log value.
-	cfg := Config{svcBaseURI: svc, ipxeBaseURI: ipxe, ruleLog: "debug"}
+	cfg := Config{svcBaseURI: svc, ipxeURI: ipxe, ruleLog: "debug"}
 	cfg.rules = []rule.Rule{{Name: "r1", Log: "", Action: rule.Action{Hostname: "nid{04d}"}}}
 
 	_, errs := cfg.validate()
@@ -128,7 +188,7 @@ func TestConfigValidate_RuleLogInheritance(t *testing.T) {
 	}
 
 	// Explicit rule log must override global.
-	cfg = Config{svcBaseURI: svc, ipxeBaseURI: ipxe, ruleLog: "debug"}
+	cfg = Config{svcBaseURI: svc, ipxeURI: ipxe, ruleLog: "debug"}
 	cfg.rules = []rule.Rule{{Name: "r1", Log: "none", Action: rule.Action{Hostname: "nid{04d}"}}}
 	_, errs = cfg.validate()
 	if len(errs) != 0 {
@@ -143,7 +203,7 @@ func TestConfigValidate_DefaultsApplied(t *testing.T) {
 	svc, _ := url.Parse("https://svc.example.test")
 	ipxe, _ := url.Parse("https://ipxe.example.test")
 
-	cfg := Config{svcBaseURI: svc, ipxeBaseURI: ipxe}
+	cfg := Config{svcBaseURI: svc, ipxeURI: ipxe}
 	warns, errs := cfg.validate()
 	if len(errs) != 0 {
 		t.Fatalf("validate() errs=%v", errs)
@@ -171,7 +231,7 @@ func TestConfigValidate_DefaultsApplied(t *testing.T) {
 func TestParseConfig_SubnetAutoBuiltFromRules(t *testing.T) {
 	base := []string{
 		"svc_base_uri=https://svc.example.test",
-		"ipxe_base_uri=https://ipxe.example.test",
+		"ipxe_uri=https://ipxe.example.test/bootscript",
 	}
 
 	// Single rule with subnet match auto-builds SubnetContext
@@ -235,7 +295,7 @@ func TestParseConfig_SubnetAutoBuiltFromRules(t *testing.T) {
 func TestParseConfig_SubnetWithRules(t *testing.T) {
 	args := []string{
 		"svc_base_uri=https://svc.example.test",
-		"ipxe_base_uri=https://ipxe.example.test",
+		"ipxe_uri=https://ipxe.example.test/bootscript",
 		"rule=subnet:10.40.1.0/24,type:Node,hostname:compute-{04d},routers:10.40.1.1,cidr:24",
 		"rule=subnet:10.40.3.0/24,type:Node,hostname:storage-{04d},routers:10.40.3.1,cidr:24",
 		"rule=type:NodeBMC,hostname:bmc{04d}",


### PR DESCRIPTION
### Description

Instead of requiring the configurer to provide a base URI and have a hard-coded `/boot/v1/bootscript` be appended, provide full customization of the boot script URI so that either BSS (`/boot/v1/bootscript`) or boot-service (`/bootscript` or some other configured endpoint) can be used.

Remove `ipxe_base_uri`, which only supports providing a base URI, with `ipxe_uri`, which supports providing a full URI.

BREAKING CHANGE: `ipxe_base_uri`, a required field, is replaced by `ipxe_uri`

Fixes #64 

### Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have added/updated comments where needed  
- [x] I have added tests that prove my fix is effective or my feature works  
- [x] I have run `make test` (or equivalent) locally and all tests pass  
- [x] **DCO Sign-off**: All commits are signed off (`git commit -s`) with my real name and email  
- [x] **REUSE Compliance**:  
  - [x] Each new/modified source file has SPDX copyright and license headers  
  - [x] Any non-commentable files include a `<filename>.license` sidecar  
  - [x] All referenced licenses are present in the `LICENSES/` directory  

### Type of Change

- [ ] Bug fix  
- [x] New feature  
- [x] Breaking change  
- [x] Documentation update  

---

For more info, see [Contributing Guidelines](https://github.com/OpenCHAMI/.github/blob/main/CODE_OF_CONDUCT.md).
